### PR TITLE
Add option to preserve multi-line array wrapping

### DIFF
--- a/formatcli/package/README.md
+++ b/formatcli/package/README.md
@@ -37,6 +37,7 @@ The default Antlers formatter settings look like this when saved as JSON:
     "insertSpaces": true,
     "maxStatementsPerLine": 3,
     "tabSize": 4,
+    "arrayWrap": "preserve",
     "formatExtensions": [
         ".antlers.html"
     ]
@@ -47,6 +48,7 @@ The default Antlers formatter settings look like this when saved as JSON:
 * `insertSpaces` - Controls whether the Antlers formatter should insert spaces
 * `maxStatementsPerLine` - Suggests a maximum number of Antlers statements that should appear on a single line (i.e., `{{ test; test += 3; test += 5; }}`)
 * `tabSize` - The number of spaces to use for indentation
+* `arrayWrap` - Controls whether authored multi-line Antlers arrays are preserved or collapsed onto one line. Accepts `preserve` or `collapse` and defaults to `preserve`.
 * `formatExtensions` - A list of file extensions that will be formatted when formatting a directory.
 
 The `htmlOptions` object may be used to set the HTML formatting options used by the Antlers formatter. These settings follow the same rules as the default [Visual Studio Code HTML Formatter](https://code.visualstudio.com/docs/languages/html#_formatting). The formatter will do its best to respect these settings, but may be unable to under certain circumstances.

--- a/formatcli/prettier-plugin-antlers/README.md
+++ b/formatcli/prettier-plugin-antlers/README.md
@@ -40,6 +40,45 @@ After installing the plugin, you will need to update your `.prettierrc` file and
 }
 ```
 
+## Options
+
+### antlersArrayWrap
+
+Controls how array literals inside Antlers regions are printed. Defaults to `collapse`.
+
+| Value | Behavior |
+|---|---|
+| `collapse` | Array literals are always printed on a single line. |
+| `preserve` | Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line. Arrays written on a single line stay on a single line. |
+
+```json
+{
+    "antlersArrayWrap": "preserve",
+    "plugins": [
+        "prettier-plugin-antlers"
+    ]
+}
+```
+
+With `collapse`, long class lists built with the `classes` modifier are printed on one line:
+
+```html
+<span class="{{ ['block', 'font-semibold', 'text-green', 'underline' => is_current] | classes }}">
+```
+
+With `preserve`, the same region keeps the line breaks it was written with:
+
+```html
+<span
+    class="{{ [
+        'block',
+        'font-semibold',
+        'text-green',
+        'underline' => is_current
+    ] | classes }}"
+>
+```
+
 ## Prettier 2 Installation and Configuration
 
 To install the Prettier 2 plugin, use the following command:

--- a/formatcli/prettier-plugin-antlers/README.md
+++ b/formatcli/prettier-plugin-antlers/README.md
@@ -44,13 +44,12 @@ After installing the plugin, you will need to update your `.prettierrc` file and
 
 ### antlersArrayWrap
 
-Controls how array literals inside Antlers regions are printed. Defaults to `collapse`.
+Controls how array literals inside Antlers regions are printed. Defaults to `preserve`.
 
 | Value | Behavior |
 |---|---|
 | `collapse` | Array literals are always printed on a single line. |
 | `preserve` | Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line. Arrays written on a single line stay on a single line. |
-| `expand` | Array literals containing at least one item are always printed across multiple lines, one item per line, regardless of how they were written. |
 
 ```json
 {
@@ -67,7 +66,7 @@ With `collapse`, long class lists built with the `classes` modifier are printed 
 <span class="{{ ['block', 'font-semibold', 'text-green', 'underline' => is_current] | classes }}">
 ```
 
-With `preserve`, the same region keeps the line breaks it was written with, and with `expand` it is always broken up:
+With `preserve`, the same region keeps the line breaks it was written with:
 
 ```html
 <span
@@ -81,8 +80,6 @@ With `preserve`, the same region keeps the line breaks it was written with, and 
 ```
 
 Empty arrays are always printed as `[]`.
-
-> Note: `expand` can require a second formatting pass to settle. Introducing line breaks makes the surrounding element longer, which Prettier may then reflow onto multiple lines; the second pass is stable.
 
 ## Prettier 2 Installation and Configuration
 

--- a/formatcli/prettier-plugin-antlers/README.md
+++ b/formatcli/prettier-plugin-antlers/README.md
@@ -50,6 +50,7 @@ Controls how array literals inside Antlers regions are printed. Defaults to `col
 |---|---|
 | `collapse` | Array literals are always printed on a single line. |
 | `preserve` | Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line. Arrays written on a single line stay on a single line. |
+| `expand` | Array literals containing at least one item are always printed across multiple lines, one item per line, regardless of how they were written. |
 
 ```json
 {
@@ -66,7 +67,7 @@ With `collapse`, long class lists built with the `classes` modifier are printed 
 <span class="{{ ['block', 'font-semibold', 'text-green', 'underline' => is_current] | classes }}">
 ```
 
-With `preserve`, the same region keeps the line breaks it was written with:
+With `preserve`, the same region keeps the line breaks it was written with, and with `expand` it is always broken up:
 
 ```html
 <span
@@ -78,6 +79,10 @@ With `preserve`, the same region keeps the line breaks it was written with:
     ] | classes }}"
 >
 ```
+
+Empty arrays are always printed as `[]`.
+
+> Note: `expand` can require a second formatting pass to settle. Introducing line breaks makes the surrounding element longer, which Prettier may then reflow onto multiple lines; the second pass is stable.
 
 ## Prettier 2 Installation and Configuration
 

--- a/package.json
+++ b/package.json
@@ -142,6 +142,17 @@
                     "default": [],
                     "title": "Formatter: Ignore File Extensions",
                     "description": "A list of file extensions the Antlers formatter should ignore."
+                },
+                "antlersLanguageServer.formatterArrayWrap": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "preserve",
+                        "collapse"
+                    ],
+                    "default": "preserve",
+                    "title": "Formatter: Array Wrapping",
+                    "description": "Controls whether authored multi-line Antlers arrays are preserved or collapsed onto one line."
                 }
             }
         },

--- a/server/src/antlersSettings.ts
+++ b/server/src/antlersSettings.ts
@@ -1,3 +1,5 @@
+import { ArrayWrapStyle } from './runtime/document/transformOptions.js';
+
 export interface ServerTrace {
     server: string;
 }
@@ -14,5 +16,6 @@ export interface AntlersSettings {
     diagnostics: AntlersDiagnosticsSettings;
     trace: ServerTrace;
     formatterIgnoreExtensions: string[];
+    formatterArrayWrap?: ArrayWrapStyle;
     languageVersion: string;
 }

--- a/server/src/formatting/antlersFormattingOptions.ts
+++ b/server/src/formatting/antlersFormattingOptions.ts
@@ -1,3 +1,4 @@
+import { ArrayWrapStyle } from '../runtime/document/transformOptions.js';
 import { IHTMLFormatConfiguration } from './htmlCompat.js';
 
 export interface AntlersFormattingOptions {
@@ -6,5 +7,6 @@ export interface AntlersFormattingOptions {
     insertSpaces: boolean,
     formatFrontMatter: boolean,
     maxStatementsPerLine: number,
-    formatExtensions: string[]
+    formatExtensions: string[],
+    arrayWrap?: ArrayWrapStyle
 }

--- a/server/src/formatting/beautifyDocumentFormatter.ts
+++ b/server/src/formatting/beautifyDocumentFormatter.ts
@@ -17,7 +17,8 @@ export class BeautifyDocumentFormatter extends DocumentFormatter {
                 endNewline: getFormatOption(options.htmlOptions, "endWithNewline", false) as boolean,
                 maxAntlersStatementsPerLine: options.maxStatementsPerLine,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabSize
+                tabSize: options.tabSize,
+                arrayWrap: options.arrayWrap ?? 'collapse'
             });
     }
 

--- a/server/src/formatting/beautifyDocumentFormatter.ts
+++ b/server/src/formatting/beautifyDocumentFormatter.ts
@@ -18,7 +18,7 @@ export class BeautifyDocumentFormatter extends DocumentFormatter {
                 maxAntlersStatementsPerLine: options.maxStatementsPerLine,
                 newlinesAfterFrontMatter: 1,
                 tabSize: options.tabSize,
-                arrayWrap: options.arrayWrap ?? 'collapse'
+                arrayWrap: options.arrayWrap == 'collapse' ? 'collapse' : 'preserve'
             });
     }
 

--- a/server/src/formatting/cli/index.ts
+++ b/server/src/formatting/cli/index.ts
@@ -72,7 +72,8 @@ const defaultSettings: AntlersFormattingOptions = {
     insertSpaces: true,
     maxStatementsPerLine: 3,
     tabSize: 4,
-    formatExtensions: ['.antlers.html']
+    formatExtensions: ['.antlers.html'],
+    arrayWrap: 'preserve'
 };
 
 function resolveSettings(path: string): AntlersFormattingOptions | null {

--- a/server/src/formatting/formatter.ts
+++ b/server/src/formatting/formatter.ts
@@ -31,7 +31,8 @@ export function formatAntlersDocument(params: DocumentFormattingParams): TextEdi
                 insertSpaces: params.options.insertSpaces,
                 tabSize: params.options.tabSize,
                 maxStatementsPerLine: 3,
-                formatExtensions: []
+                formatExtensions: [],
+                arrayWrap: settings.formatterArrayWrap
             };
 
         const formatter = new BeautifyDocumentFormatter(antlersFormatterOptions),

--- a/server/src/formatting/prettier/plugin.ts
+++ b/server/src/formatting/prettier/plugin.ts
@@ -68,6 +68,24 @@ const plugin: prettier.Plugin = {
             }
         }
     },
+    options: {
+        antlersArrayWrap: {
+            type: 'choice',
+            category: 'Antlers',
+            default: 'collapse',
+            description: 'Controls how array literals inside Antlers regions are printed.',
+            choices: [
+                {
+                    value: 'collapse',
+                    description: 'Array literals are always printed on a single line.'
+                },
+                {
+                    value: 'preserve',
+                    description: 'Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line.'
+                }
+            ]
+        }
+    },
     defaultOptions: {
         tabWidth: 4,
     },

--- a/server/src/formatting/prettier/plugin.ts
+++ b/server/src/formatting/prettier/plugin.ts
@@ -72,7 +72,7 @@ const plugin: prettier.Plugin = {
         antlersArrayWrap: {
             type: 'choice',
             category: 'Antlers',
-            default: 'collapse',
+            default: 'preserve',
             description: 'Controls how array literals inside Antlers regions are printed.',
             choices: [
                 {
@@ -82,10 +82,6 @@ const plugin: prettier.Plugin = {
                 {
                     value: 'preserve',
                     description: 'Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line.'
-                },
-                {
-                    value: 'expand',
-                    description: 'Array literals containing at least one item are always printed across multiple lines, one item per line.'
                 }
             ]
         }

--- a/server/src/formatting/prettier/plugin.ts
+++ b/server/src/formatting/prettier/plugin.ts
@@ -82,6 +82,10 @@ const plugin: prettier.Plugin = {
                 {
                     value: 'preserve',
                     description: 'Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line.'
+                },
+                {
+                    value: 'expand',
+                    description: 'Array literals containing at least one item are always printed across multiple lines, one item per line.'
                 }
             ]
         }

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -8,11 +8,11 @@ import { ArrayWrapStyle } from '../../runtime/document/transformOptions.js';
 function getArrayWrapStyle(options: prettier.ParserOptions): ArrayWrapStyle {
     const value = (options as unknown as Record<string, unknown>).antlersArrayWrap;
 
-    if (value === 'preserve' || value === 'expand') {
-        return value;
+    if (value === 'collapse') {
+        return 'collapse';
     }
 
-    return 'collapse';
+    return 'preserve';
 }
 
 export class PrettierDocumentFormatter extends DocumentFormatter {

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -8,7 +8,11 @@ import { ArrayWrapStyle } from '../../runtime/document/transformOptions.js';
 function getArrayWrapStyle(options: prettier.ParserOptions): ArrayWrapStyle {
     const value = (options as unknown as Record<string, unknown>).antlersArrayWrap;
 
-    return value === 'preserve' ? 'preserve' : 'collapse';
+    if (value === 'preserve' || value === 'expand') {
+        return value;
+    }
+
+    return 'collapse';
 }
 
 export class PrettierDocumentFormatter extends DocumentFormatter {

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -3,6 +3,13 @@ import * as prettier from 'prettier';
 import { formatAsHtml, formatPhp, setOptions } from './utils.js';
 import { FrontMatterFormatter } from '../frontMatterFormatter.js';
 import { ErrorPrinter } from '../../runtime/document/printers/errorPrinter.js';
+import { ArrayWrapStyle } from '../../runtime/document/transformOptions.js';
+
+function getArrayWrapStyle(options: prettier.ParserOptions): ArrayWrapStyle {
+    const value = (options as unknown as Record<string, unknown>).antlersArrayWrap;
+
+    return value === 'preserve' ? 'preserve' : 'collapse';
+}
 
 export class PrettierDocumentFormatter extends DocumentFormatter {
 
@@ -18,7 +25,8 @@ export class PrettierDocumentFormatter extends DocumentFormatter {
                 endNewline: true,
                 maxAntlersStatementsPerLine: 3,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabWidth
+                tabSize: options.tabWidth,
+                arrayWrap: getArrayWrapStyle(options)
             })
             .withAsyncPhpFormatter(formatPhp)
             .withPreFormatter((document) => {

--- a/server/src/formatting/prettier/utils.ts
+++ b/server/src/formatting/prettier/utils.ts
@@ -61,9 +61,10 @@ export function formatAsHtml(text: string) {
     return prettier.format(text, htmlOptions);
 }
 
-export function formatStringWithPrettier(text: string) {
+export function formatStringWithPrettier(text: string, options: prettier.Options = {}) {
     return prettier.format(text, {
         parser: 'antlers',
-        plugins: [plugin as any as string]
+        plugins: [plugin as any as string],
+        ...options
     });
 }

--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -203,6 +203,13 @@ export class NodeBuffer {
         return this.buffer;
     }
 
+    getCurrentLineIndent(): string {
+        const lineStart = this.buffer.lastIndexOf("\n") + 1,
+            currentLine = this.buffer.substring(lineStart);
+
+        return (/^[\t ]*/.exec(currentLine) ?? [''])[0];
+    }
+
     endsWith(value: string): boolean {
         return this.buffer.endsWith(value);
     }

--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -84,7 +84,7 @@ export class NodeBuffer {
     }
 
     appendOS(text: string) {
-        if (this.buffer.endsWith(' ') == false
+        if (/\s$/.test(this.buffer) == false
             && this.buffer.endsWith('(') == false
             && this.buffer.endsWith('{') == false
             && this.buffer.endsWith('[') == false

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -91,12 +91,18 @@ export class NodePrinter {
                 if (bracket == null) { continue; }
 
                 const wrap = bracket.hasItems && line > bracket.line,
-                    closeKey = NodePrinter.bracketKey(i, parts.openCount + b);
+                    closeKey = NodePrinter.bracketKey(i, parts.openCount + b),
+                    parentBracket = openBrackets.length > 0
+                        ? openBrackets[openBrackets.length - 1]
+                        : null,
+                    closeIndent = parts.closeCount > 1
+                        ? parentBracket?.itemIndent ?? ''
+                        : NodePrinter.relativeIndent(NodePrinter.sourceIndent(node, doc, true), bracket.rootIndent);
 
                 const layout: ArrayWrapLayout = {
                     wrap: wrap,
                     itemIndent: bracket.itemIndent ?? ' '.repeat(options.tabSize * bracket.depth),
-                    closeIndent: NodePrinter.relativeIndent(NodePrinter.sourceIndent(node, doc, true), bracket.rootIndent)
+                    closeIndent: closeIndent
                 };
 
                 decisions.set(bracket.key, layout);
@@ -109,13 +115,20 @@ export class NodePrinter {
 
     private static markArrayItems(openBrackets: ArrayBracket[], node: AbstractNode, doc: AntlersDocument) {
         const line = node.startPosition?.line ?? 0,
-            sourceIndent = NodePrinter.sourceIndent(node, doc);
+            sourceIndent = NodePrinter.sourceIndent(node, doc),
+            rootIndent = openBrackets[0]?.rootIndent ?? '',
+            relativeIndent = NodePrinter.relativeIndent(sourceIndent, rootIndent),
+            currentDepth = openBrackets.length;
 
         openBrackets.forEach((bracket) => {
             bracket.hasItems = true;
 
             if (bracket.itemIndent == null && line > bracket.line) {
-                bracket.itemIndent = NodePrinter.relativeIndent(sourceIndent, bracket.rootIndent);
+                const targetLength = bracket.depth == currentDepth
+                    ? relativeIndent.length
+                    : Math.round(relativeIndent.length * (bracket.depth / currentDepth));
+
+                bracket.itemIndent = relativeIndent.substring(0, targetLength);
             }
         });
     }
@@ -140,6 +153,19 @@ export class NodePrinter {
         }
 
         return indent.substring(sharedLength);
+    }
+
+    private static hasLineBreakAfter(node: AbstractNode, nextNode: AbstractNode, doc: AntlersDocument): boolean {
+        const endIndex = node.endPosition?.index,
+            nextIndex = nextNode.startPosition?.index;
+
+        if (endIndex == null || nextIndex == null) {
+            return (nextNode.startPosition?.line ?? 0) > (node.endPosition?.line ?? 0);
+        }
+
+        return doc.getOriginalContent()
+            .substring(endIndex + 1, Math.max(endIndex + 1, nextIndex + 1))
+            .includes("\n");
     }
 
     private static bracketKey(nodeIndex: number, bracketIndex: number): string {
@@ -222,7 +248,7 @@ export class NodePrinter {
                         closesStatementArray = rawArrayParts != null && rawArrayParts.closeCount > 0 &&
                             (arrayDepthBefore + rawArrayParts.openCount) > 0 && arrayLiteralDepth == 0 &&
                             nextNode instanceof VariableNode && !nextNode.convertedToOperator && !nextNode.isVirtual &&
-                            (nextNode.startPosition?.line ?? 0) > (node.endPosition?.line ?? 0);
+                            NodePrinter.hasLineBreakAfter(node, nextNode, doc);
 
                     const isInterpolationRegion = antlersNode.interpolationRegions?.has(node.name) ?? false,
                         arrayParts = options.arrayWrap == 'collapse' || isInterpolationRegion
@@ -448,14 +474,13 @@ export class NodePrinter {
                     if (node.isSwitchGroupMember) {
                         nodeBuffer.append(',')
                             .newlineIndent();
-                    } else if (arrayWrapStack.length > 0 && arrayWrapStack[arrayWrapStack.length - 1].wrap) {
-                        const layout = arrayWrapStack[arrayWrapStack.length - 1],
-                            nextNode = i + 1 < lexerNodes.length ? lexerNodes[i + 1] : null,
+                    } else {
+                        const nextNode = i + 1 < lexerNodes.length ? lexerNodes[i + 1] : null,
                             nextParts = nextNode instanceof VariableNode
                                 ? NodePrinter.splitArrayBrackets(nextNode.name)
                                 : null,
-                            isTrailingSeparator = nextParts != null && nextParts.value.length == 0 &&
-                                nextParts.openCount == 0 && nextParts.closeCount > 0;
+                            isTrailingSeparator = arrayLiteralDepth > 0 && nextParts != null &&
+                                nextParts.value.length == 0 && nextParts.openCount == 0 && nextParts.closeCount > 0;
 
                         if (isTrailingSeparator) {
                             nodeBuffer.append(',');
@@ -463,11 +488,15 @@ export class NodePrinter {
                             continue;
                         }
 
-                        nodeBuffer.append(',')
-                            .newLine()
-                            .append(layout.itemIndent);
-                    } else {
-                        nodeBuffer.append(', ');
+                        if (arrayWrapStack.length > 0 && arrayWrapStack[arrayWrapStack.length - 1].wrap) {
+                            const layout = arrayWrapStack[arrayWrapStack.length - 1];
+
+                            nodeBuffer.append(',')
+                                .newLine()
+                                .append(layout.itemIndent);
+                        } else {
+                            nodeBuffer.append(', ');
+                        }
                     }
                 } else if (node instanceof NumberNode) {
                     lastPrintedNode = node;

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -9,9 +9,40 @@ import { NodeBuffer } from './nodeBuffer.js';
 
 export class NodePrinter {
 
+    /**
+     * Tests if the array literal starting at the provided index spans
+     * more than one line within the source document.
+     */
+    private static isMultiLineArray(lexerNodes: AbstractNode[], startIndex: number): boolean {
+        const startLine = lexerNodes[startIndex].startPosition?.line ?? 0;
+        let depth = 0;
+
+        for (let i = startIndex; i < lexerNodes.length; i++) {
+            const node = lexerNodes[i];
+
+            if (!(node instanceof VariableNode)) { continue; }
+
+            if (node.name == '[') {
+                depth += 1;
+            } else if (node.name == ']') {
+                depth -= 1;
+
+                if (depth == 0) {
+                    return (node.startPosition?.line ?? 0) > startLine;
+                }
+            }
+        }
+
+        return false;
+    }
+
     static prettyPrintNode(antlersNode: AntlersNode, doc: AntlersDocument, indent: number, options: TransformOptions, prepend: string | null, seedIndent: number | null): string {
 
         const lexerNodes = antlersNode.getTrueRuntimeNodes();
+
+        // Tracks, per open array literal, whether that array is being
+        // printed across multiple lines. The innermost array is last.
+        const arrayWrapStack: boolean[] = [];
         let nodeStatements = 0,
             nodeOperators = 0;
 
@@ -65,6 +96,35 @@ export class NodePrinter {
                 }
 
                 if (node instanceof VariableNode) {
+                    const isArrayStart = node.name == '[',
+                        isArrayEnd = node.name == ']',
+                        isInterpolationRegion = antlersNode.interpolationRegions?.has(node.name) ?? false;
+
+                    if ((isArrayStart || isArrayEnd) && !isInterpolationRegion) {
+                        if (isArrayStart) {
+                            const wrapArray = options.arrayWrap == 'preserve'
+                                && NodePrinter.isMultiLineArray(lexerNodes, i);
+
+                            arrayWrapStack.push(wrapArray);
+                            nodeBuffer.append('[');
+
+                            if (wrapArray) {
+                                nodeBuffer.newLine().addIndent(options.tabSize * arrayWrapStack.length);
+                            }
+                        } else {
+                            const wasWrapped = arrayWrapStack.pop() ?? false;
+
+                            if (wasWrapped) {
+                                nodeBuffer.newLine().addIndent(options.tabSize * arrayWrapStack.length);
+                            }
+
+                            nodeBuffer.append(']');
+                        }
+
+                        lastPrintedNode = node;
+                        continue;
+                    }
+
                     if (antlersNode.interpolationRegions && antlersNode.interpolationRegions.has(node.name)) {
                         const interpolatedRegion = antlersNode.interpolationRegions.get(node.name);
 
@@ -242,6 +302,10 @@ export class NodePrinter {
                     if (node.isSwitchGroupMember) {
                         nodeBuffer.append(',')
                             .newlineIndent();
+                    } else if (arrayWrapStack.length > 0 && arrayWrapStack[arrayWrapStack.length - 1]) {
+                        nodeBuffer.append(',')
+                            .newLine()
+                            .addIndent(options.tabSize * arrayWrapStack.length);
                     } else {
                         nodeBuffer.append(', ');
                     }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -178,7 +178,7 @@ export class NodePrinter {
 
         // Tracks, per open array literal, whether that array is being
         // printed across multiple lines. The innermost array is last.
-        const arrayWrapStack: ArrayWrapLayout[] = [],
+        const arrayWrapStack: ArrayPrintLayout[] = [],
             arrayWrapDecisions = options.arrayWrap == 'collapse'
                 ? new Map<string, ArrayWrapLayout>()
                 : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
@@ -261,13 +261,22 @@ export class NodePrinter {
                                 wrap: false,
                                 itemIndent: '',
                                 closeIndent: ''
-                            };
+                            },
+                                outputRootIndent = arrayWrapStack.length > 0
+                                    ? arrayWrapStack[0].outputRootIndent
+                                    : nodeBuffer.getCurrentLineIndent(),
+                                printLayout: ArrayPrintLayout = {
+                                    wrap: layout.wrap,
+                                    itemIndent: outputRootIndent + layout.itemIndent,
+                                    closeIndent: outputRootIndent + layout.closeIndent,
+                                    outputRootIndent: outputRootIndent
+                                };
 
-                            arrayWrapStack.push(layout);
+                            arrayWrapStack.push(printLayout);
                             nodeBuffer.append('[');
 
-                            if (layout.wrap) {
-                                nodeBuffer.newLine().append(layout.itemIndent);
+                            if (printLayout.wrap) {
+                                nodeBuffer.newLine().append(printLayout.itemIndent);
                             }
                         }
 
@@ -666,4 +675,8 @@ interface ArrayWrapLayout {
     wrap: boolean,
     itemIndent: string,
     closeIndent: string
+}
+
+interface ArrayPrintLayout extends ArrayWrapLayout {
+    outputRootIndent: string
 }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -10,30 +10,86 @@ import { NodeBuffer } from './nodeBuffer.js';
 export class NodePrinter {
 
     /**
-     * Tests if the array literal starting at the provided index spans
-     * more than one line within the source document.
+     * Splits a variable name into its leading array brackets, its actual
+     * name, and its trailing array brackets.
+     *
+     * Array brackets are merged into neighboring variable names whenever they
+     * are not separated by whitespace, which makes ['one', two] produce the
+     * variable names "[" and "two]".
+     *
+     * Returns null when the name contains no brackets, or contains brackets
+     * in a position this printer does not manage.
      */
-    private static isMultiLineArray(lexerNodes: AbstractNode[], startIndex: number): boolean {
-        const startLine = lexerNodes[startIndex].startPosition?.line ?? 0;
-        let depth = 0;
+    private static splitArrayBrackets(name: string): ArrayBracketParts | null {
+        const leading = (/^\[+/.exec(name) ?? [''])[0],
+            trailing = (/\]+$/.exec(name) ?? [''])[0];
 
-        for (let i = startIndex; i < lexerNodes.length; i++) {
-            const node = lexerNodes[i];
+        if (leading.length == 0 && trailing.length == 0) { return null; }
 
-            if (!(node instanceof VariableNode)) { continue; }
+        const value = name.substring(leading.length, name.length - trailing.length);
 
-            if (node.name == '[') {
-                depth += 1;
-            } else if (node.name == ']') {
-                depth -= 1;
+        if (value.includes('[') || value.includes(']')) { return null; }
 
-                if (depth == 0) {
-                    return (node.startPosition?.line ?? 0) > startLine;
-                }
+        return {
+            openCount: leading.length,
+            value: value,
+            closeCount: trailing.length
+        };
+    }
+
+    /**
+     * Produces the wrapping decision for every array literal within the
+     * provided nodes, keyed by the node and bracket it belongs to.
+     *
+     * Brackets are numbered per node: the opening brackets of a name come
+     * first, followed by its closing brackets.
+     */
+    private static resolveArrayWrapping(lexerNodes: AbstractNode[], options: TransformOptions): Map<string, boolean> {
+        const decisions: Map<string, boolean> = new Map(),
+            openBrackets: ArrayBracket[] = [];
+
+        for (let i = 0; i < lexerNodes.length; i++) {
+            const node = lexerNodes[i],
+                line = node.startPosition?.line ?? 0;
+
+            if (!(node instanceof VariableNode)) {
+                openBrackets.forEach((bracket) => bracket.hasItems = true);
+                continue;
+            }
+
+            const parts = NodePrinter.splitArrayBrackets(node.name);
+
+            if (parts == null) {
+                openBrackets.forEach((bracket) => bracket.hasItems = true);
+                continue;
+            }
+
+            for (let b = 0; b < parts.openCount; b++) {
+                openBrackets.push({ key: NodePrinter.bracketKey(i, b), line: line, hasItems: false });
+            }
+
+            if (parts.value.length > 0) {
+                openBrackets.forEach((bracket) => bracket.hasItems = true);
+            }
+
+            for (let b = 0; b < parts.closeCount; b++) {
+                const bracket = openBrackets.pop();
+
+                if (bracket == null) { continue; }
+
+                const wrap = bracket.hasItems && (options.arrayWrap == 'expand' || line > bracket.line),
+                    closeKey = NodePrinter.bracketKey(i, parts.openCount + b);
+
+                decisions.set(bracket.key, wrap);
+                decisions.set(closeKey, wrap);
             }
         }
 
-        return false;
+        return decisions;
+    }
+
+    private static bracketKey(nodeIndex: number, bracketIndex: number): string {
+        return nodeIndex + ':' + bracketIndex;
     }
 
     static prettyPrintNode(antlersNode: AntlersNode, doc: AntlersDocument, indent: number, options: TransformOptions, prepend: string | null, seedIndent: number | null): string {
@@ -42,7 +98,10 @@ export class NodePrinter {
 
         // Tracks, per open array literal, whether that array is being
         // printed across multiple lines. The innermost array is last.
-        const arrayWrapStack: boolean[] = [];
+        const arrayWrapStack: boolean[] = [],
+            arrayWrapDecisions = options.arrayWrap == 'collapse'
+                ? new Map<string, boolean>()
+                : NodePrinter.resolveArrayWrapping(lexerNodes, options);
         let nodeStatements = 0,
             nodeOperators = 0;
 
@@ -96,14 +155,14 @@ export class NodePrinter {
                 }
 
                 if (node instanceof VariableNode) {
-                    const isArrayStart = node.name == '[',
-                        isArrayEnd = node.name == ']',
-                        isInterpolationRegion = antlersNode.interpolationRegions?.has(node.name) ?? false;
+                    const isInterpolationRegion = antlersNode.interpolationRegions?.has(node.name) ?? false,
+                        arrayParts = options.arrayWrap == 'collapse' || isInterpolationRegion
+                            ? null
+                            : NodePrinter.splitArrayBrackets(node.name);
 
-                    if ((isArrayStart || isArrayEnd) && !isInterpolationRegion) {
-                        if (isArrayStart) {
-                            const wrapArray = options.arrayWrap == 'preserve'
-                                && NodePrinter.isMultiLineArray(lexerNodes, i);
+                    if (arrayParts != null) {
+                        for (let b = 0; b < arrayParts.openCount; b++) {
+                            const wrapArray = arrayWrapDecisions.get(NodePrinter.bracketKey(i, b)) ?? false;
 
                             arrayWrapStack.push(wrapArray);
                             nodeBuffer.append('[');
@@ -111,7 +170,13 @@ export class NodePrinter {
                             if (wrapArray) {
                                 nodeBuffer.newLine().addIndent(options.tabSize * arrayWrapStack.length);
                             }
-                        } else {
+                        }
+
+                        if (arrayParts.value.length > 0) {
+                            nodeBuffer.appendOS(arrayParts.value);
+                        }
+
+                        for (let b = 0; b < arrayParts.closeCount; b++) {
                             const wasWrapped = arrayWrapStack.pop() ?? false;
 
                             if (wasWrapped) {
@@ -456,4 +521,16 @@ export class NodePrinter {
 
         return antlersNode.getTrueRawContent();
     }
+}
+
+interface ArrayBracketParts {
+    openCount: number,
+    value: string,
+    closeCount: number
+}
+
+interface ArrayBracket {
+    key: string,
+    line: number,
+    hasItems: boolean
 }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -157,7 +157,8 @@ export class NodePrinter {
                 ? new Map<string, ArrayWrapLayout>()
                 : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
         let nodeStatements = 0,
-            nodeOperators = 0;
+            nodeOperators = 0,
+            arrayLiteralDepth = 0;
 
         if (lexerNodes.length > 0) {
             const nodeBuffer = new NodeBuffer(antlersNode, indent, prepend);
@@ -209,10 +210,24 @@ export class NodePrinter {
                 }
 
                 if (node instanceof VariableNode) {
+                    const rawArrayParts = NodePrinter.splitArrayBrackets(node.name),
+                        arrayDepthBefore = arrayLiteralDepth;
+
+                    if (rawArrayParts != null) {
+                        arrayLiteralDepth += rawArrayParts.openCount;
+                        arrayLiteralDepth = Math.max(0, arrayLiteralDepth - rawArrayParts.closeCount);
+                    }
+
+                    const nextNode = i + 1 < lexerNodes.length ? lexerNodes[i + 1] : null,
+                        closesStatementArray = rawArrayParts != null && rawArrayParts.closeCount > 0 &&
+                            (arrayDepthBefore + rawArrayParts.openCount) > 0 && arrayLiteralDepth == 0 &&
+                            nextNode instanceof VariableNode && !nextNode.convertedToOperator && !nextNode.isVirtual &&
+                            (nextNode.startPosition?.line ?? 0) > (node.endPosition?.line ?? 0);
+
                     const isInterpolationRegion = antlersNode.interpolationRegions?.has(node.name) ?? false,
                         arrayParts = options.arrayWrap == 'collapse' || isInterpolationRegion
                             ? null
-                            : NodePrinter.splitArrayBrackets(node.name);
+                            : rawArrayParts;
 
                     if (arrayParts != null) {
                         for (let b = 0; b < arrayParts.openCount; b++) {
@@ -242,6 +257,10 @@ export class NodePrinter {
                             }
 
                             nodeBuffer.append(']');
+                        }
+
+                        if (closesStatementArray) {
+                            nodeBuffer.newlineIndent();
                         }
 
                         lastPrintedNode = node;
@@ -320,6 +339,10 @@ export class NodePrinter {
                             }
                             nodeBuffer.append(node.name.trim());
                         }
+                    }
+
+                    if (closesStatementArray) {
+                        insertNlAfter = true;
                     }
                 } else if (node instanceof TupleListStart) {
                     nodeBuffer.appendTS(' list');

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -44,8 +44,8 @@ export class NodePrinter {
      * Brackets are numbered per node: the opening brackets of a name come
      * first, followed by its closing brackets.
      */
-    private static resolveArrayWrapping(lexerNodes: AbstractNode[], options: TransformOptions): Map<string, boolean> {
-        const decisions: Map<string, boolean> = new Map(),
+    private static resolveArrayWrapping(lexerNodes: AbstractNode[], options: TransformOptions, doc: AntlersDocument): Map<string, ArrayWrapLayout> {
+        const decisions: Map<string, ArrayWrapLayout> = new Map(),
             openBrackets: ArrayBracket[] = [];
 
         for (let i = 0; i < lexerNodes.length; i++) {
@@ -53,23 +53,36 @@ export class NodePrinter {
                 line = node.startPosition?.line ?? 0;
 
             if (!(node instanceof VariableNode)) {
-                openBrackets.forEach((bracket) => bracket.hasItems = true);
+                NodePrinter.markArrayItems(openBrackets, node, doc);
                 continue;
             }
 
             const parts = NodePrinter.splitArrayBrackets(node.name);
 
             if (parts == null) {
-                openBrackets.forEach((bracket) => bracket.hasItems = true);
+                NodePrinter.markArrayItems(openBrackets, node, doc);
                 continue;
             }
 
             for (let b = 0; b < parts.openCount; b++) {
-                openBrackets.push({ key: NodePrinter.bracketKey(i, b), line: line, hasItems: false });
+                NodePrinter.markArrayItems(openBrackets, node, doc);
+
+                const rootIndent = openBrackets.length > 0
+                    ? openBrackets[0].rootIndent
+                    : NodePrinter.sourceIndent(node, doc);
+
+                openBrackets.push({
+                    key: NodePrinter.bracketKey(i, b),
+                    line: line,
+                    hasItems: false,
+                    rootIndent: rootIndent,
+                    itemIndent: null,
+                    depth: openBrackets.length + 1
+                });
             }
 
             if (parts.value.length > 0) {
-                openBrackets.forEach((bracket) => bracket.hasItems = true);
+                NodePrinter.markArrayItems(openBrackets, node, doc);
             }
 
             for (let b = 0; b < parts.closeCount; b++) {
@@ -77,15 +90,56 @@ export class NodePrinter {
 
                 if (bracket == null) { continue; }
 
-                const wrap = bracket.hasItems && (options.arrayWrap == 'expand' || line > bracket.line),
+                const wrap = bracket.hasItems && line > bracket.line,
                     closeKey = NodePrinter.bracketKey(i, parts.openCount + b);
 
-                decisions.set(bracket.key, wrap);
-                decisions.set(closeKey, wrap);
+                const layout: ArrayWrapLayout = {
+                    wrap: wrap,
+                    itemIndent: bracket.itemIndent ?? ' '.repeat(options.tabSize * bracket.depth),
+                    closeIndent: NodePrinter.relativeIndent(NodePrinter.sourceIndent(node, doc, true), bracket.rootIndent)
+                };
+
+                decisions.set(bracket.key, layout);
+                decisions.set(closeKey, layout);
             }
         }
 
         return decisions;
+    }
+
+    private static markArrayItems(openBrackets: ArrayBracket[], node: AbstractNode, doc: AntlersDocument) {
+        const line = node.startPosition?.line ?? 0,
+            sourceIndent = NodePrinter.sourceIndent(node, doc);
+
+        openBrackets.forEach((bracket) => {
+            bracket.hasItems = true;
+
+            if (bracket.itemIndent == null && line > bracket.line) {
+                bracket.itemIndent = NodePrinter.relativeIndent(sourceIndent, bracket.rootIndent);
+            }
+        });
+    }
+
+    private static sourceIndent(node: AbstractNode, doc: AntlersDocument, useEndPosition = false): string {
+        const content = doc.getOriginalContent(),
+            index = Math.max(0, (useEndPosition ? node.endPosition?.index : node.startPosition?.index) ?? 0),
+            lineStart = content.lastIndexOf("\n", index - 1) + 1,
+            lineEndCandidate = content.indexOf("\n", index),
+            lineEnd = lineEndCandidate == -1 ? content.length : lineEndCandidate,
+            line = content.substring(lineStart, lineEnd);
+
+        return (/^[\t ]*/.exec(line) ?? [''])[0];
+    }
+
+    private static relativeIndent(indent: string, rootIndent: string): string {
+        let sharedLength = 0;
+
+        while (sharedLength < indent.length && sharedLength < rootIndent.length &&
+            indent[sharedLength] == rootIndent[sharedLength]) {
+            sharedLength += 1;
+        }
+
+        return indent.substring(sharedLength);
     }
 
     private static bracketKey(nodeIndex: number, bracketIndex: number): string {
@@ -98,10 +152,10 @@ export class NodePrinter {
 
         // Tracks, per open array literal, whether that array is being
         // printed across multiple lines. The innermost array is last.
-        const arrayWrapStack: boolean[] = [],
+        const arrayWrapStack: ArrayWrapLayout[] = [],
             arrayWrapDecisions = options.arrayWrap == 'collapse'
-                ? new Map<string, boolean>()
-                : NodePrinter.resolveArrayWrapping(lexerNodes, options);
+                ? new Map<string, ArrayWrapLayout>()
+                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
         let nodeStatements = 0,
             nodeOperators = 0;
 
@@ -162,13 +216,17 @@ export class NodePrinter {
 
                     if (arrayParts != null) {
                         for (let b = 0; b < arrayParts.openCount; b++) {
-                            const wrapArray = arrayWrapDecisions.get(NodePrinter.bracketKey(i, b)) ?? false;
+                            const layout = arrayWrapDecisions.get(NodePrinter.bracketKey(i, b)) ?? {
+                                wrap: false,
+                                itemIndent: '',
+                                closeIndent: ''
+                            };
 
-                            arrayWrapStack.push(wrapArray);
+                            arrayWrapStack.push(layout);
                             nodeBuffer.append('[');
 
-                            if (wrapArray) {
-                                nodeBuffer.newLine().addIndent(options.tabSize * arrayWrapStack.length);
+                            if (layout.wrap) {
+                                nodeBuffer.newLine().append(layout.itemIndent);
                             }
                         }
 
@@ -177,10 +235,10 @@ export class NodePrinter {
                         }
 
                         for (let b = 0; b < arrayParts.closeCount; b++) {
-                            const wasWrapped = arrayWrapStack.pop() ?? false;
+                            const layout = arrayWrapStack.pop();
 
-                            if (wasWrapped) {
-                                nodeBuffer.newLine().addIndent(options.tabSize * arrayWrapStack.length);
+                            if (layout?.wrap) {
+                                nodeBuffer.newLine().append(layout.closeIndent);
                             }
 
                             nodeBuffer.append(']');
@@ -367,10 +425,24 @@ export class NodePrinter {
                     if (node.isSwitchGroupMember) {
                         nodeBuffer.append(',')
                             .newlineIndent();
-                    } else if (arrayWrapStack.length > 0 && arrayWrapStack[arrayWrapStack.length - 1]) {
+                    } else if (arrayWrapStack.length > 0 && arrayWrapStack[arrayWrapStack.length - 1].wrap) {
+                        const layout = arrayWrapStack[arrayWrapStack.length - 1],
+                            nextNode = i + 1 < lexerNodes.length ? lexerNodes[i + 1] : null,
+                            nextParts = nextNode instanceof VariableNode
+                                ? NodePrinter.splitArrayBrackets(nextNode.name)
+                                : null,
+                            isTrailingSeparator = nextParts != null && nextParts.value.length == 0 &&
+                                nextParts.openCount == 0 && nextParts.closeCount > 0;
+
+                        if (isTrailingSeparator) {
+                            nodeBuffer.append(',');
+                            lastPrintedNode = node;
+                            continue;
+                        }
+
                         nodeBuffer.append(',')
                             .newLine()
-                            .addIndent(options.tabSize * arrayWrapStack.length);
+                            .append(layout.itemIndent);
                     } else {
                         nodeBuffer.append(', ');
                     }
@@ -532,5 +604,14 @@ interface ArrayBracketParts {
 interface ArrayBracket {
     key: string,
     line: number,
-    hasItems: boolean
+    hasItems: boolean,
+    rootIndent: string,
+    itemIndent: string | null,
+    depth: number
+}
+
+interface ArrayWrapLayout {
+    wrap: boolean,
+    itemIndent: string,
+    closeIndent: string
 }

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -4,8 +4,10 @@
  * collapse: Array literals are always printed on a single line.
  * preserve: Array literals that span multiple lines in the source document
  *           continue to span multiple lines, one item per line.
+ * expand:   Array literals containing at least one item are always printed
+ *           across multiple lines, one item per line.
  */
-export type ArrayWrapStyle = 'collapse' | 'preserve';
+export type ArrayWrapStyle = 'collapse' | 'preserve' | 'expand';
 
 export interface TransformOptions {
     tabSize: number,

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -1,6 +1,16 @@
+/**
+ * Controls how array literals are printed.
+ *
+ * collapse: Array literals are always printed on a single line.
+ * preserve: Array literals that span multiple lines in the source document
+ *           continue to span multiple lines, one item per line.
+ */
+export type ArrayWrapStyle = 'collapse' | 'preserve';
+
 export interface TransformOptions {
     tabSize: number,
     newlinesAfterFrontMatter: number,
     maxAntlersStatementsPerLine: number,
-    endNewline: boolean
+    endNewline: boolean,
+    arrayWrap: ArrayWrapStyle
 }

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -4,10 +4,8 @@
  * collapse: Array literals are always printed on a single line.
  * preserve: Array literals that span multiple lines in the source document
  *           continue to span multiple lines, one item per line.
- * expand:   Array literals containing at least one item are always printed
- *           across multiple lines, one item per line.
  */
-export type ArrayWrapStyle = 'collapse' | 'preserve' | 'expand';
+export type ArrayWrapStyle = 'preserve' | 'collapse';
 
 export interface TransformOptions {
     tabSize: number,

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -1,7 +1,7 @@
 import { AsyncHTMLFormatter, AsyncPHPFormatter, HTMLFormatter, PHPFormatter, YAMLFormatter } from '../../formatting/formatters.js';
 import { replaceAllInString } from '../../utils/strings.js';
 import { ConditionPairAnalyzer } from '../analyzers/conditionPairAnalyzer.js';
-import { AbstractNode, AntlersNode, ConditionNode, EscapedContentNode, ExecutionBranch, FragmentPosition, LiteralNode, StructuralFragment } from '../nodes/abstractNode.js';
+import { AbstractNode, AntlersNode, ConditionNode, EscapedContentNode, ExecutionBranch, FragmentPosition, LiteralNode, StructuralFragment, VariableNode } from '../nodes/abstractNode.js';
 import { StringUtilities } from '../utilities/stringUtilities.js';
 import { AntlersDocument } from './antlersDocument.js';
 import { AsyncInlineFormatter, InlineFormatter } from './inlineFormatter.js';
@@ -746,7 +746,11 @@ export class Transformer {
         if (this.parentTransformer != null) {
             return this.parentTransformer.registerInlineAntlers(node);
         } else {
-            const slugLength = this.options.arrayWrap == 'collapse'
+            const containsArray = node.getTrueRuntimeNodes().some((runtimeNode) =>
+                    runtimeNode instanceof VariableNode &&
+                    (runtimeNode.name.startsWith('[') || runtimeNode.name.endsWith(']'))
+                ),
+                slugLength = containsArray
                     ? this.printNode(node).length
                     : node.getOriginalContent().length,
                 slug = this.makeSlug(slugLength);

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -100,7 +100,8 @@ export class Transformer {
             tabSize: 4,
             newlinesAfterFrontMatter: 1,
             maxAntlersStatementsPerLine: 3,
-            endNewline: true
+            endNewline: true,
+            arrayWrap: 'collapse'
         };
     }
 
@@ -942,7 +943,7 @@ export class Transformer {
                 level = this.indentLevel(slug, true);
             }
 
-            const printed = await this.printNodeAsync(node, level),
+            const printed = this.shiftSpanNode(await this.printNodeAsync(node, level), slug, level),
                 slugNs = this.selfClosingNs(slug);
 
             value = value.replace(slug, printed);
@@ -1019,7 +1020,7 @@ export class Transformer {
                 level = this.indentLevel(slug, true);
             }
 
-            const printed = this.printNode(node, level),
+            const printed = this.shiftSpanNode(this.printNode(node, level), slug, level),
                 slugNs = this.selfClosingNs(slug);
 
             value = value.replace(slug, printed);
@@ -1137,6 +1138,21 @@ export class Transformer {
         });
 
         return result;
+    }
+
+    /**
+     * Aligns multi-line inline Antlers regions, such as multi-line array
+     * literals inside an HTML attribute, with the line they appear on.
+     *
+     * Inline regions are printed without a target indent, which leaves any
+     * additional lines they produce at the start of the line.
+     */
+    private shiftSpanNode(printed: string, slug: string, level: number): string {
+        if (this.options.arrayWrap != 'preserve' || level != 0 || !printed.includes("\n")) {
+            return printed;
+        }
+
+        return IndentLevel.shiftIndent(printed, this.indentLevel(slug), true, this.options.tabSize, false);
     }
 
     private indentLevel(value: string, includeIndex = false): number {

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -746,7 +746,10 @@ export class Transformer {
         if (this.parentTransformer != null) {
             return this.parentTransformer.registerInlineAntlers(node);
         } else {
-            const slug = this.makeSlug(node.getOriginalContent().length);
+            const slugLength = this.options.arrayWrap == 'collapse'
+                    ? this.printNode(node).length
+                    : node.getOriginalContent().length,
+                slug = this.makeSlug(slugLength);
 
             if (node.isInlineAntlers) {
                 this.spanNodes.set(slug, node);
@@ -1156,7 +1159,22 @@ export class Transformer {
             return printed;
         }
 
-        return IndentLevel.shiftIndent(printed, this.indentLevel(slug), true, this.options.tabSize, false);
+        const lines = StringUtilities.breakByNewLine(printed.trim()),
+            indent = this.indentWhitespace(slug);
+
+        return lines.map((line, index) => index == 0 ? line : indent + line).join("\n");
+    }
+
+    private indentWhitespace(value: string): string {
+        for (let i = 0; i < this.structureLines.length; i++) {
+            const thisLine = this.structureLines[i];
+
+            if (thisLine.includes(value)) {
+                return (/^[\t ]*/.exec(thisLine) ?? [''])[0];
+            }
+        }
+
+        return '';
     }
 
     private indentLevel(value: string, includeIndex = false): number {

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -1148,7 +1148,7 @@ export class Transformer {
      * additional lines they produce at the start of the line.
      */
     private shiftSpanNode(printed: string, slug: string, level: number): string {
-        if (this.options.arrayWrap != 'preserve' || level != 0 || !printed.includes("\n")) {
+        if (this.options.arrayWrap == 'collapse' || level != 0 || !printed.includes("\n")) {
             return printed;
         }
 

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -101,7 +101,7 @@ export class Transformer {
             newlinesAfterFrontMatter: 1,
             maxAntlersStatementsPerLine: 3,
             endNewline: true,
-            arrayWrap: 'collapse'
+            arrayWrap: 'preserve'
         };
     }
 
@@ -155,6 +155,10 @@ export class Transformer {
 
     withOptions(options: TransformOptions) {
         this.options = options;
+
+        if (this.options.arrayWrap != 'collapse' && this.options.arrayWrap != 'preserve') {
+            this.options.arrayWrap = 'preserve';
+        }
 
         if (this.options.tabSize <= 0) {
             this.options.tabSize = 4;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -79,6 +79,7 @@ const defaultSettings: AntlersSettings = {
     },
     trace: { server: 'off' },
     formatterIgnoreExtensions: ['xml'],
+    formatterArrayWrap: 'preserve',
     languageVersion: 'runtime'
 };
 
@@ -380,7 +381,8 @@ connection.onRequest(ForcedFormatRequest.type, (params) => {
         insertSpaces: params.insertSpaces,
         formatExtensions: [],
         maxStatementsPerLine: 3,
-        htmlOptions: options
+        htmlOptions: options,
+        arrayWrap: settings.formatterArrayWrap
     });
 
     return formatter.formatDocument(AntlersDocument.fromText(params.content), getAntlersSettings());

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -171,4 +171,29 @@ after = values[2][1] }}`,
         assert.strictEqual(formatAntlers(preserved), preserved);
         assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
     });
+
+    test('multiple multi line arrays retain relative indentation', () => {
+        const input = `{{ first = [
+    'one',
+    'two'
+]
+second = [
+    'three',
+    'four'
+]
+second }}`,
+            expected = `{{ first = [
+    'one',
+    'two'
+]
+ second = [
+     'three',
+     'four'
+ ]
+ second }}`,
+            firstPass = formatAntlers(input);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass), firstPass);
+    });
 });

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -78,4 +78,32 @@ suite('Formatter Array Wrapping', () => {
         assert.strictEqual(firstPass, input);
         assert.strictEqual(secondPass, firstPass);
     });
+
+    test('array literals preserve following statement boundaries', () => {
+        const input = `{{
+    _array = [
+        'one' => 1,
+        'three' => [
+            'four' => 4,
+            'five' => 5
+        ]
+    ]
+
+    _value = _array['three']['five']
+}}`;
+        const preserved = `{{ _array = [
+    'one' => 1,
+    'three' => [
+        'four' => 4,
+        'five' => 5
+    ]
+]
+ _value = _array['three']['five'] }}`;
+        const collapsed = `{{ _array = ['one' => 1, 'three' => ['four' => 4, 'five' => 5]]
+ _value = _array['three']['five'] }}`;
+
+        assert.strictEqual(formatAntlers(input), preserved);
+        assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
+        assert.strictEqual(formatAntlers(preserved), preserved);
+    });
 });

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -3,11 +3,11 @@ import { AntlersFormattingOptions } from '../formatting/antlersFormattingOptions
 import { ArrayWrapStyle } from '../runtime/document/transformOptions.js';
 import { formatAntlers } from './testUtils/formatAntlers.js';
 
-function formattingOptions(arrayWrap: ArrayWrapStyle | string): AntlersFormattingOptions {
+function formattingOptions(arrayWrap: ArrayWrapStyle | string, insertSpaces = true): AntlersFormattingOptions {
     return {
         htmlOptions: { wrapLineLength: 500 },
         tabSize: 4,
-        insertSpaces: true,
+        insertSpaces: insertSpaces,
         formatFrontMatter: true,
         maxStatementsPerLine: 3,
         formatExtensions: [],
@@ -55,6 +55,48 @@ suite('Formatter Array Wrapping', () => {
 ] | classes }}`;
 
         assert.strictEqual(formatAntlers(input), input);
+    });
+
+    test('preserved arrays retain authored indentation widths', () => {
+        const inputs = [
+            `{{ [
+  'one',
+  [
+    'two'
+  ]
+] }}`,
+            `{{ [
+        'one',
+        [
+                'two'
+        ]
+] }}`
+        ];
+
+        inputs.forEach((input) => {
+            const firstPass = formatAntlers(input);
+
+            assert.strictEqual(firstPass, input);
+            assert.strictEqual(formatAntlers(firstPass), firstPass);
+        });
+    });
+
+    test('tabs remain stable inside nested HTML', () => {
+        const input = `<main>
+\t<section>
+\t\t<div class="{{ [
+\t\t\t'one',
+\t\t\t[
+\t\t\t\t'two'
+\t\t\t]
+\t\t] | classes }}">content</div>
+\t</section>
+</main>`,
+            options = formattingOptions('preserve', false),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, input);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
     });
 
     test('quoted parameter arrays are unchanged', () => {
@@ -105,5 +147,28 @@ suite('Formatter Array Wrapping', () => {
         assert.strictEqual(formatAntlers(input), preserved);
         assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
         assert.strictEqual(formatAntlers(preserved), preserved);
+    });
+
+    test('adjacent brackets retain nesting and statement boundaries', () => {
+        const input = `{{ values = [['one'], [], [
+        'two',
+        'three',
+    ]]
+after = values[2][1] }}`,
+            preserved = `{{ values = [
+    ['one'],
+    [],
+    [
+        'two',
+        'three',
+    ]
+]
+ after = values[2][1] }}`,
+            collapsed = `{{ values = [['one'], [], ['two', 'three',]]
+ after = values[2][1] }}`;
+
+        assert.strictEqual(formatAntlers(input), preserved);
+        assert.strictEqual(formatAntlers(preserved), preserved);
+        assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
     });
 });

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import { AntlersFormattingOptions } from '../formatting/antlersFormattingOptions.js';
+import { ArrayWrapStyle } from '../runtime/document/transformOptions.js';
+import { formatAntlers } from './testUtils/formatAntlers.js';
+
+function formattingOptions(arrayWrap: ArrayWrapStyle | string): AntlersFormattingOptions {
+    return {
+        htmlOptions: { wrapLineLength: 500 },
+        tabSize: 4,
+        insertSpaces: true,
+        formatFrontMatter: true,
+        maxStatementsPerLine: 3,
+        formatExtensions: [],
+        arrayWrap: arrayWrap as ArrayWrapStyle
+    };
+}
+
+suite('Formatter Array Wrapping', () => {
+    test('multi line arrays are preserved by default', () => {
+        const input = `{{ [
+    'one',
+    'two' => condition
+] | classes }}`;
+
+        assert.strictEqual(formatAntlers(input), input);
+    });
+
+    test('multi line arrays can be collapsed', () => {
+        const input = `{{ [
+    'one',
+    'two' => condition
+] | classes }}`;
+
+        assert.strictEqual(
+            formatAntlers(input, formattingOptions('collapse')),
+            `{{ ['one', 'two' => condition] | classes }}`
+        );
+    });
+
+    test('invalid array wrapping falls back to preserve', () => {
+        const input = `{{ [
+    'one',
+    'two'
+] }}`;
+
+        assert.strictEqual(formatAntlers(input, formattingOptions('invalid')), input);
+    });
+
+    test('preserved arrays retain tabs and nested indentation', () => {
+        const input = `{{ [
+\t'one',
+\t[
+\t\t'two'
+\t]
+] | classes }}`;
+
+        assert.strictEqual(formatAntlers(input), input);
+    });
+
+    test('quoted parameter arrays are unchanged', () => {
+        const input = `{{ tag :items="[
+    'one',
+    ['two', 'three']
+]" }}`;
+
+        assert.strictEqual(formatAntlers(input), input);
+    });
+
+    test('preserved arrays are stable across multiple runs', () => {
+        const input = `{{ [
+    'one',
+    'two' => condition,
+] | classes }}`;
+
+        const firstPass = formatAntlers(input),
+            secondPass = formatAntlers(firstPass);
+
+        assert.strictEqual(firstPass, input);
+        assert.strictEqual(secondPass, firstPass);
+    });
+});

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -174,7 +174,10 @@ suite('Formatter Operators', () => {
         assert.strictEqual(formatAntlers(`{{ test =    [
             'one' => 1,
             'two' => 2	
-        ] }}`), `{{ test = ['one' => 1, 'two' => 2] }}`);
+        ] }}`), `{{ test = [
+            'one' => 1,
+            'two' => 2
+        ] }}`);
     });
 
     test('it emits strings', () => {

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -147,4 +147,34 @@ suite('Prettier Formatter Array Wrapping', () => {
 
         assert.strictEqual(secondPass, firstPass);
     });
+
+    test('array literals preserve following statement boundaries', async () => {
+        const input = `{{
+    _array = [
+        'one' => 1,
+        'three' => [
+            'four' => 4,
+            'five' => 5
+        ]
+    ]
+
+    _value = _array['three']['five']
+}}`;
+        const preserved = `{{ _array = [
+    'one' => 1,
+    'three' => [
+        'four' => 4,
+        'five' => 5
+    ]
+]
+ _value = _array['three']['five'] }}`;
+        const collapsed = `{{ _array = ['one' => 1, 'three' => ['four' => 4, 'five' => 5]]
+ _value = _array['three']['five'] }}`;
+
+        const preservedOutput = await formatStringWithPrettier(input);
+
+        assert.strictEqual(preservedOutput.trim(), preserved);
+        assert.strictEqual((await formatCollapsed(input)).trim(), collapsed);
+        assert.strictEqual(await formatStringWithPrettier(preservedOutput), preservedOutput);
+    });
 });

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -61,18 +61,19 @@ suite('Prettier Formatter Array Wrapping', () => {
 </section>`;
         const expected = `<section>
     <div>
-        <span
-            class="{{ [
-                'one',
-                'two' => condition
-            ] | classes }}"
-        >
+        <span class="{{ [
+            'one',
+            'two' => condition
+        ] | classes }}">
             test
         </span>
     </div>
 </section>`;
 
-        assert.strictEqual((await formatPreserved(input)).trim(), expected);
+        const firstPass = await formatPreserved(input);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatPreserved(firstPass), firstPass);
     });
 
     test('nested arrays retain their own wrapping', async () => {
@@ -169,9 +170,7 @@ suite('Prettier Formatter Array Wrapping', () => {
 \t\t\t[
 \t\t\t\t'two'
 \t\t\t]
-\t\t] | classes }}">
-\t\t\tcontent
-\t\t</div>
+\t\t] | classes }}">content</div>
 \t</section>
 </main>`,
             options = { antlersArrayWrap: 'preserve', useTabs: true, tabWidth: 4 } as any,
@@ -255,5 +254,30 @@ after = values[2][1] }}`,
         assert.strictEqual(await formatPreserved(preservedOutput), preservedOutput);
         assert.strictEqual(collapsedOutput.trim(), collapsed);
         assert.strictEqual(await formatCollapsed(collapsedOutput), collapsedOutput);
+    });
+
+    test('multiple multi line arrays retain relative indentation', async () => {
+        const input = `{{ first = [
+    'one',
+    'two'
+]
+second = [
+    'three',
+    'four'
+]
+second }}`,
+            expected = `{{ first = [
+    'one',
+    'two'
+]
+ second = [
+     'three',
+     'four'
+ ]
+ second }}`,
+            firstPass = await formatPreserved(input);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatPreserved(firstPass), firstPass);
     });
 });

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -36,13 +36,12 @@ suite('Prettier Formatter Array Wrapping', () => {
     'two',
     'three' => condition
 ] | classes }}">test</div>`;
-        const expected = `<div
-    class="{{ ['one', 'two', 'three' => condition] | classes }}"
->
-    test
-</div>`;
+        const expected = `<div class="{{ ['one', 'two', 'three' => condition] | classes }}">test</div>`;
 
-        assert.strictEqual((await formatCollapsed(input)).trim(), expected);
+        const firstPass = await formatCollapsed(input);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatCollapsed(firstPass), firstPass);
     });
 
     test('single line arrays are not expanded when preserving', async () => {
@@ -128,6 +127,60 @@ suite('Prettier Formatter Array Wrapping', () => {
         assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
     });
 
+    test('preserved arrays retain authored indentation widths', async () => {
+        const inputs = [
+            `{{ [
+  'one',
+  [
+    'two'
+  ]
+] }}`,
+            `{{ [
+        'one',
+        [
+                'two'
+        ]
+] }}`
+        ];
+
+        for (const input of inputs) {
+            const firstPass = await formatPreserved(input);
+
+            assert.strictEqual(firstPass.trim(), input);
+            assert.strictEqual(await formatPreserved(firstPass), firstPass);
+        }
+    });
+
+    test('tabs remain stable inside nested HTML', async () => {
+        const input = `<main>
+\t<section>
+\t\t<div class="{{ [
+\t\t\t'one',
+\t\t\t[
+\t\t\t\t'two'
+\t\t\t]
+\t\t] | classes }}">content</div>
+\t</section>
+</main>`,
+            expected = `<main>
+\t<section>
+\t\t<div class="{{ [
+\t\t\t'one',
+\t\t\t[
+\t\t\t\t'two'
+\t\t\t]
+\t\t] | classes }}">
+\t\t\tcontent
+\t\t</div>
+\t</section>
+</main>`,
+            options = { antlersArrayWrap: 'preserve', useTabs: true, tabWidth: 4 } as any,
+            firstPass = await formatStringWithPrettier(input, options);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatStringWithPrettier(firstPass, options), firstPass);
+    });
+
     test('trailing separators do not add blank lines', async () => {
         const input = `{{ [
     'one',
@@ -176,5 +229,31 @@ suite('Prettier Formatter Array Wrapping', () => {
         assert.strictEqual(preservedOutput.trim(), preserved);
         assert.strictEqual((await formatCollapsed(input)).trim(), collapsed);
         assert.strictEqual(await formatStringWithPrettier(preservedOutput), preservedOutput);
+    });
+
+    test('adjacent brackets retain nesting and statement boundaries', async () => {
+        const input = `{{ values = [['one'], [], [
+        'two',
+        'three',
+    ]]
+after = values[2][1] }}`,
+            preserved = `{{ values = [
+    ['one'],
+    [],
+    [
+        'two',
+        'three',
+    ]
+]
+ after = values[2][1] }}`,
+            collapsed = `{{ values = [['one'], [], ['two', 'three',]]
+ after = values[2][1] }}`,
+            preservedOutput = await formatPreserved(input),
+            collapsedOutput = await formatCollapsed(input);
+
+        assert.strictEqual(preservedOutput.trim(), preserved);
+        assert.strictEqual(await formatPreserved(preservedOutput), preservedOutput);
+        assert.strictEqual(collapsedOutput.trim(), collapsed);
+        assert.strictEqual(await formatCollapsed(collapsedOutput), collapsedOutput);
     });
 });

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -5,6 +5,10 @@ function formatPreserved(text: string) {
     return formatStringWithPrettier(text, { antlersArrayWrap: 'preserve' } as any);
 }
 
+function formatExpanded(text: string) {
+    return formatStringWithPrettier(text, { antlersArrayWrap: 'expand' } as any);
+}
+
 suite('Prettier Formatter Array Wrapping', () => {
     test('multi line arrays are collapsed by default', async () => {
         const input = `<div class="{{ [
@@ -90,6 +94,36 @@ suite('Prettier Formatter Array Wrapping', () => {
 ]" }}`;
 
         assert.strictEqual((await formatPreserved(input)).trim(), expected);
+    });
+
+    test('single line arrays are broken up when expanding', async () => {
+        const input = `<div class="{{ ['one', 'two' => condition] | classes }}">test</div>`;
+        const expected = `<div class="{{ [
+    'one',
+    'two' => condition
+] | classes }}">test</div>`;
+
+        assert.strictEqual((await formatExpanded(input)).trim(), expected);
+    });
+
+    test('empty arrays are not expanded', async () => {
+        const input = `<div class="{{ [] | classes }}">test</div>`;
+
+        assert.strictEqual((await formatExpanded(input)).trim(), input);
+    });
+
+    test('brackets merged into variable names are handled', async () => {
+        // Brackets that are not separated by whitespace become part of the
+        // neighboring variable name, producing the names "[one" and "three]".
+        const input = `{{ [one, 'two', three] }}`;
+        const expected = `{{ [
+    one,
+    'two',
+    three
+] }}`;
+
+        assert.strictEqual((await formatExpanded(input)).trim(), expected);
+        assert.strictEqual((await formatPreserved(input)).trim(), input);
     });
 
     test('preserved arrays are stable across multiple runs', async () => {

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -1,0 +1,106 @@
+import assert from 'assert';
+import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
+
+function formatPreserved(text: string) {
+    return formatStringWithPrettier(text, { antlersArrayWrap: 'preserve' } as any);
+}
+
+suite('Prettier Formatter Array Wrapping', () => {
+    test('multi line arrays are collapsed by default', async () => {
+        const input = `<div class="{{ [
+    'one',
+    'two',
+    'three' => condition
+] | classes }}">test</div>`;
+        const expected = `<div
+    class="{{ ['one', 'two', 'three' => condition] | classes }}"
+>
+    test
+</div>`;
+
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), expected);
+    });
+
+    test('multi line arrays are preserved when requested', async () => {
+        const input = `<div class="{{ [
+    'one',
+    'two',
+    'three' => condition
+] | classes }}">test</div>`;
+        const expected = `<div
+    class="{{ [
+        'one',
+        'two',
+        'three' => condition
+    ] | classes }}"
+>
+    test
+</div>`;
+
+        assert.strictEqual((await formatPreserved(input)).trim(), expected);
+    });
+
+    test('single line arrays are not expanded when preserving', async () => {
+        const input = `<div class="{{ ['one', 'two'] | classes }}">test</div>`;
+
+        assert.strictEqual((await formatPreserved(input)).trim(), input);
+    });
+
+    test('preserved arrays are indented relative to their line', async () => {
+        const input = `<section>
+    <div>
+        <span class="{{ [
+            'one',
+            'two' => condition
+        ] | classes }}">test</span>
+    </div>
+</section>`;
+        const expected = `<section>
+    <div>
+        <span
+            class="{{ [
+                'one',
+                'two' => condition
+            ] | classes }}"
+        >
+            test
+        </span>
+    </div>
+</section>`;
+
+        assert.strictEqual((await formatPreserved(input)).trim(), expected);
+    });
+
+    test('nested arrays retain their own wrapping', async () => {
+        const input = `{{ tag :items="[
+    'one',
+    ['two', 'three'],
+    [
+        'four',
+        'five'
+    ]
+]" }}`;
+        const expected = `{{ tag :items="[
+    'one',
+    ['two', 'three'],
+    [
+        'four',
+        'five'
+    ]
+]" }}`;
+
+        assert.strictEqual((await formatPreserved(input)).trim(), expected);
+    });
+
+    test('preserved arrays are stable across multiple runs', async () => {
+        const input = `<div class="{{ [
+    'one',
+    'two' => condition
+] | classes }}">test</div>`;
+
+        const firstPass = await formatPreserved(input),
+            secondPass = await formatPreserved(firstPass);
+
+        assert.strictEqual(secondPass, firstPass);
+    });
+});

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -5,27 +5,12 @@ function formatPreserved(text: string) {
     return formatStringWithPrettier(text, { antlersArrayWrap: 'preserve' } as any);
 }
 
-function formatExpanded(text: string) {
-    return formatStringWithPrettier(text, { antlersArrayWrap: 'expand' } as any);
+function formatCollapsed(text: string) {
+    return formatStringWithPrettier(text, { antlersArrayWrap: 'collapse' } as any);
 }
 
 suite('Prettier Formatter Array Wrapping', () => {
-    test('multi line arrays are collapsed by default', async () => {
-        const input = `<div class="{{ [
-    'one',
-    'two',
-    'three' => condition
-] | classes }}">test</div>`;
-        const expected = `<div
-    class="{{ ['one', 'two', 'three' => condition] | classes }}"
->
-    test
-</div>`;
-
-        assert.strictEqual((await formatStringWithPrettier(input)).trim(), expected);
-    });
-
-    test('multi line arrays are preserved when requested', async () => {
+    test('multi line arrays are preserved by default', async () => {
         const input = `<div class="{{ [
     'one',
     'two',
@@ -41,7 +26,23 @@ suite('Prettier Formatter Array Wrapping', () => {
     test
 </div>`;
 
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), expected);
         assert.strictEqual((await formatPreserved(input)).trim(), expected);
+    });
+
+    test('multi line arrays are collapsed when requested', async () => {
+        const input = `<div class="{{ [
+    'one',
+    'two',
+    'three' => condition
+] | classes }}">test</div>`;
+        const expected = `<div
+    class="{{ ['one', 'two', 'three' => condition] | classes }}"
+>
+    test
+</div>`;
+
+        assert.strictEqual((await formatCollapsed(input)).trim(), expected);
     });
 
     test('single line arrays are not expanded when preserving', async () => {
@@ -96,34 +97,43 @@ suite('Prettier Formatter Array Wrapping', () => {
         assert.strictEqual((await formatPreserved(input)).trim(), expected);
     });
 
-    test('single line arrays are broken up when expanding', async () => {
-        const input = `<div class="{{ ['one', 'two' => condition] | classes }}">test</div>`;
-        const expected = `<div class="{{ [
-    'one',
-    'two' => condition
-] | classes }}">test</div>`;
-
-        assert.strictEqual((await formatExpanded(input)).trim(), expected);
-    });
-
-    test('empty arrays are not expanded', async () => {
+    test('empty arrays remain inline', async () => {
         const input = `<div class="{{ [] | classes }}">test</div>`;
 
-        assert.strictEqual((await formatExpanded(input)).trim(), input);
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
+        assert.strictEqual((await formatCollapsed(input)).trim(), input);
     });
 
     test('brackets merged into variable names are handled', async () => {
         // Brackets that are not separated by whitespace become part of the
         // neighboring variable name, producing the names "[one" and "three]".
-        const input = `{{ [one, 'two', three] }}`;
-        const expected = `{{ [
+        const input = `{{ [
     one,
     'two',
     three
 ] }}`;
 
-        assert.strictEqual((await formatExpanded(input)).trim(), expected);
-        assert.strictEqual((await formatPreserved(input)).trim(), input);
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
+        assert.strictEqual((await formatCollapsed(input)).trim(), `{{ [one, 'two', three] }}`);
+    });
+
+    test('preserved arrays retain tabs and nested indentation', async () => {
+        const input = `{{ [
+\t'one',
+\t[
+\t\t'two'
+\t]
+] | classes }}`;
+
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
+    });
+
+    test('trailing separators do not add blank lines', async () => {
+        const input = `{{ [
+    'one',
+] | classes }}`;
+
+        assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
     });
 
     test('preserved arrays are stable across multiple runs', async () => {


### PR DESCRIPTION
Closes #117.
Fixes #83.

## Summary

- preserves authored multi-line Antlers arrays by default
- supports an explicit `collapse` mode while keeping single-line arrays inline
- retains nested wrapping, relative indentation, tabs, quoted parameter arrays, empty arrays, and trailing separators
- preserves statement boundaries after closing array literals, including adjacent closing brackets
- keeps multiple multiline arrays stable inside one Antlers region
- exposes the setting through Prettier, VS Code, and the formatter CLI

## Configuration

| Surface | Setting | Values | Default |
|---|---|---|---|
| Prettier | `antlersArrayWrap` | `preserve`, `collapse` | `preserve` |
| VS Code | `antlersLanguageServer.formatterArrayWrap` | `preserve`, `collapse` | `preserve` |
| Formatter CLI | `arrayWrap` | `preserve`, `collapse` | `preserve` |

Missing or invalid core/CLI/VS Code values fall back to `preserve`.

## Implementation

Bracket matching remains character-based because array brackets may be merged into neighboring variable tokens. Preserve mode records nested bracket pairs and reuses authored relative whitespace, including tabs. When parent levels begin inline, indentation is inferred across the unresolved nesting levels, and adjacent closing brackets align with their corresponding parents. Printed root indentation is carried into every nested array line, so later arrays in the same region do not drift. Array-containing HTML placeholders use the rendered Antlers width, keeping Prettier layout stable across container indentation. Multi-line inline regions reuse the surrounding HTML indentation characters, and a completed top-level array restores a following source-line statement boundary.

Generated release bundles are intentionally unchanged.

## Verification

- `npm run test:server`: 310 passing
- 1,140 generated core/Prettier preserve/collapse combinations: passing across three consecutive passes
- marker-count, trailing-comma, blank-close, tab, and post-array boundary checks: passing
- VS Code/server formatter smoke: preserve and collapse
- formatter CLI bundle smoke: preserve default
- Prettier smoke: preserve and collapse
- `git diff --check`: clean