### PR TITLE
Fix formatting integrity regressions

### DIFF
--- a/server/src/formatting/beautifyDocumentFormatter.ts
+++ b/server/src/formatting/beautifyDocumentFormatter.ts
@@ -17,7 +17,8 @@ export class BeautifyDocumentFormatter extends DocumentFormatter {
                 endNewline: getFormatOption(options.htmlOptions, "endWithNewline", false) as boolean,
                 maxAntlersStatementsPerLine: options.maxStatementsPerLine,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabSize
+                tabSize: options.tabSize,
+                insertSpaces: options.insertSpaces
             });
     }
 

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -18,7 +18,8 @@ export class PrettierDocumentFormatter extends DocumentFormatter {
                 endNewline: true,
                 maxAntlersStatementsPerLine: 3,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabWidth
+                tabSize: options.tabWidth,
+                insertSpaces: options.useTabs !== true
             })
             .withAsyncPhpFormatter(formatPhp)
             .withPreFormatter((document) => {

--- a/server/src/formatting/prettier/utils.ts
+++ b/server/src/formatting/prettier/utils.ts
@@ -61,9 +61,10 @@ export function formatAsHtml(text: string) {
     return prettier.format(text, htmlOptions);
 }
 
-export function formatStringWithPrettier(text: string) {
+export function formatStringWithPrettier(text: string, options: prettier.Options = {}) {
     return prettier.format(text, {
         parser: 'antlers',
-        plugins: [plugin as any as string]
+        plugins: [plugin as any as string],
+        ...options
     });
 }

--- a/server/src/runtime/document/printers/commentPrinter.ts
+++ b/server/src/runtime/document/printers/commentPrinter.ts
@@ -4,41 +4,77 @@ import { AsyncInlineFormatter, InlineFormatter } from '../inlineFormatter.js';
 
 export class CommentPrinter {
 
-    static printCommentLines(comment: AntlersNode, tabSize: number, targetIndent: number): string {
-        const sourceContent = comment.getContent(),
-            content = sourceContent.trim();
+    private static isDocumentationDirective(line: string): boolean {
+        return /^@(name|description|desc|entry|collection|blueprint|var|set|param\*?|format)\b/.test(line.trim());
+    }
+
+    private static isDocumentationComment(content: string): boolean {
+        return StringUtilities.breakByNewLine(content).some((line) => this.isDocumentationDirective(line));
+    }
+
+    private static indentWidth(line: string, tabSize: number): number {
+        let width = 0;
+
+        for (const char of line) {
+            if (char == ' ') {
+                width++;
+            } else if (char == '\t') {
+                width += tabSize - (width % tabSize);
+            } else {
+                break;
+            }
+        }
+
+        return width;
+    }
+
+    private static makeIndent(width: number, tabSize: number, insertSpaces: boolean): string {
+        if (insertSpaces) {
+            return ' '.repeat(width);
+        }
+
+        const tabs = Math.floor(width / tabSize),
+            spaces = width % tabSize;
+
+        return '\t'.repeat(tabs) + ' '.repeat(spaces);
+    }
+
+    private static printContent(sourceContent: string, tabSize: number, targetIndent: string, insertSpaces: boolean): string {
+        const content = sourceContent.trim();
 
         if (content.includes("\n")) {
-            const lines = StringUtilities.breakByNewLine(sourceContent),
+            const lines = StringUtilities.breakByNewLine(sourceContent);
+
+            while (lines.length > 0 && lines[0].trim().length == 0) {
+                lines.shift();
+            }
+
+            while (lines.length > 0 && lines[lines.length - 1].trim().length == 0) {
+                lines.pop();
+            }
+
+            const contentIndents = lines
+                .filter((line) => line.trim().length > 0)
+                .map((line) => this.indentWidth(line, tabSize)),
+                baseIndent = contentIndents.length > 0 ? Math.min(...contentIndents) : 0,
+                childIndent = targetIndent + this.makeIndent(tabSize, tabSize, insertSpaces),
                 reflowedLines: string[] = [];
 
             lines.forEach((line) => {
                 if (line.trim().length == 0) {
-                    reflowedLines.push(' '.repeat(tabSize + targetIndent) + line.trim());
+                    reflowedLines.push('');
                     return;
                 }
-                // Preserve relative indentation.
-                let curRelIndent = line.length - line.trim().length;
 
-                const checkLine = line.trim();
-
-                if (checkLine.startsWith('@desc') || checkLine.startsWith('@set') || checkLine.startsWith('@name')) {
-                    curRelIndent = tabSize;
-                }
-
-                reflowedLines.push(' '.repeat(tabSize + targetIndent + curRelIndent - tabSize) + line.trim());
+                const relativeIndent = this.isDocumentationDirective(line)
+                    ? 0
+                    : Math.max(0, this.indentWidth(line, tabSize) - baseIndent);
+                reflowedLines.push(childIndent + this.makeIndent(relativeIndent, tabSize, insertSpaces) + line.trim());
             });
 
-            if (reflowedLines.length > 0) {
-                if (reflowedLines[reflowedLines.length - 1].trim().length == 0) {
-                    reflowedLines.pop();
-                }
-            }
-
-            const content = reflowedLines.join("\n");
             let newComment = "{{#\n";
-            newComment += content;
-            newComment += "\n" + ' '.repeat(targetIndent) + '#}}';
+            newComment += reflowedLines.join("\n");
+            newComment += "\n" + targetIndent + '#}}';
 
             return newComment;
         }
@@ -46,11 +82,15 @@ export class CommentPrinter {
         return '{{# ' + content + ' #}}';
     }
 
-    static async printCommentAsync(comment: AntlersNode, tabSize: number, targetIndent: number, stringFormatter: AsyncInlineFormatter | null): Promise<string> {
+    static printCommentLines(comment: AntlersNode, tabSize: number, targetIndent: string, insertSpaces: boolean): string {
+        return this.printContent(comment.getContent(), tabSize, targetIndent, insertSpaces);
+    }
+
+    static async printCommentAsync(comment: AntlersNode, tabSize: number, targetIndent: string, insertSpaces: boolean, stringFormatter: AsyncInlineFormatter | null): Promise<string> {
         const sourceContent = comment.getContent(),
             content = sourceContent;
 
-        if (content.includes("\n") && !(content.includes('@desc') || content.includes('@set') || content.includes('@name'))) {
+        if (content.includes("\n") && !this.isDocumentationComment(content)) {
             try {
                 let formattedCommentContent = content;
 
@@ -58,39 +98,19 @@ export class CommentPrinter {
                     formattedCommentContent = await stringFormatter(formattedCommentContent);
                 }
 
-                const lines = StringUtilities.breakByNewLine(formattedCommentContent),
-                    reflowedLines: string[] = [];
-
-                lines.forEach((line) => {
-                    if (line.trim().length == 0) {
-                        reflowedLines.push(' '.repeat(tabSize + targetIndent) + line.trim());
-                        return;
-                    }
-                    // Preserve relative indentation.
-                    let curRelIndent = line.length - line.trim().length;
-
-                    reflowedLines.push(' '.repeat(tabSize + targetIndent + curRelIndent) + line.trim());
-                });
-
-                if (reflowedLines.length > 0) {
-                    if (reflowedLines[reflowedLines.length - 1].trim().length == 0) {
-                        reflowedLines.pop();
-                    }
-                }
-
-                return "{{#\n" + reflowedLines.join("\n") + "\n" + ' '.repeat(targetIndent) + '#}}';;
+                return this.printContent(formattedCommentContent, tabSize, targetIndent, insertSpaces);
             } catch (err) {
             }
         }
 
-        return this.printCommentLines(comment, tabSize, targetIndent);
+        return this.printCommentLines(comment, tabSize, targetIndent, insertSpaces);
     }
 
-    static printComment(comment: AntlersNode, tabSize: number, targetIndent: number, stringFormatter: InlineFormatter | null): string {
+    static printComment(comment: AntlersNode, tabSize: number, targetIndent: string, insertSpaces: boolean, stringFormatter: InlineFormatter | null): string {
         const sourceContent = comment.getContent(),
             content = sourceContent.trim();
 
-        if (content.includes("\n") && !(content.includes('@desc') || content.includes('@set') || content.includes('@name'))) {
+        if (content.includes("\n") && !this.isDocumentationComment(content)) {
             try {
                 let formattedCommentContent = content;
 
@@ -98,31 +118,11 @@ export class CommentPrinter {
                     formattedCommentContent = stringFormatter(formattedCommentContent);
                 }
 
-                const lines = StringUtilities.breakByNewLine(formattedCommentContent),
-                    reflowedLines: string[] = [];
-
-                lines.forEach((line) => {
-                    if (line.trim().length == 0) {
-                        reflowedLines.push(' '.repeat(tabSize + targetIndent) + line.trim());
-                        return;
-                    }
-                    // Preserve relative indentation.
-                    let curRelIndent = line.length - line.trim().length;
-
-                    reflowedLines.push(' '.repeat(tabSize + targetIndent + curRelIndent) + line.trim());
-                });
-
-                if (reflowedLines.length > 0) {
-                    if (reflowedLines[reflowedLines.length - 1].trim().length == 0) {
-                        reflowedLines.pop();
-                    }
-                }
-
-                return "{{#\n" + reflowedLines.join("\n") + "\n" + ' '.repeat(targetIndent) + '#}}';;
+                return this.printContent(formattedCommentContent, tabSize, targetIndent, insertSpaces);
             } catch (err) {
             }
         }
 
-        return this.printCommentLines(comment, tabSize, targetIndent);
+        return this.printCommentLines(comment, tabSize, targetIndent, insertSpaces);
     }
 }

--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -132,6 +132,12 @@ export class NodeBuffer {
     }
 
     paramS(param: ParameterNode) {
+        if (param.isShorthand) {
+            this.append(` :$${param.name}`);
+
+            return this;
+        }
+
         let bParam = ' ';
 
         if (param.isVariableReference) {

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -9,6 +9,17 @@ import { NodeBuffer } from './nodeBuffer.js';
 
 export class NodePrinter {
 
+    private static sourceContent(node: AbstractNode, doc: AntlersDocument): string {
+        const startIndex = node.startPosition?.index,
+            endIndex = node.endPosition?.index;
+
+        if (startIndex == null || endIndex == null) {
+            return '';
+        }
+
+        return doc.getOriginalContent().substring(startIndex, endIndex + 1).trim();
+    }
+
     static prettyPrintNode(antlersNode: AntlersNode, doc: AntlersDocument, indent: number, options: TransformOptions, prepend: string | null, seedIndent: number | null): string {
 
         const lexerNodes = antlersNode.getTrueRuntimeNodes();
@@ -226,7 +237,11 @@ export class NodePrinter {
 
                     nodeBuffer.append(':');
                 } else if (node instanceof ModifierValueNode) {
-                    nodeBuffer.append(node.value.trim());
+                    const sourceContent = NodePrinter.sourceContent(node, doc),
+                        isQuoted = (sourceContent.startsWith("'") && sourceContent.endsWith("'")) ||
+                            (sourceContent.startsWith('"') && sourceContent.endsWith('"'));
+
+                    nodeBuffer.append(isQuoted ? sourceContent : node.value.trim());
                 } else if (node instanceof LogicGroupBegin) {
                     nodeBuffer.append('(');
                 } else if (node instanceof LogicGroupEnd) {

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -56,10 +56,13 @@ export class NodePrinter {
                     }
                 } else {
                     if (!node.prev?.isVirtual && node.prev?.isVirtualGroupOperatorResolve && node.prev.producesVirtualStatementTerminator) {
-                        if (node.next != null) {
-                            if (!(node.prev instanceof VariableNode) && !(node.next instanceof InlineTernarySeparator) && !(node instanceof InlineTernarySeparator)) {
-                                nodeBuffer.newlineIndent();
-                            }
+                        const followsVariableStatement = node.prev instanceof VariableNode &&
+                            node instanceof VariableNode && !node.convertedToOperator && node.name != 'as' &&
+                            !doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node);
+
+                        if ((!(node.prev instanceof VariableNode) || followsVariableStatement) &&
+                            !(node.next instanceof InlineTernarySeparator) && !(node instanceof InlineTernarySeparator)) {
+                            nodeBuffer.newlineNDIndent();
                         }
                     }
                 }

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -1,5 +1,6 @@
 export interface TransformOptions {
     tabSize: number,
+    insertSpaces: boolean,
     newlinesAfterFrontMatter: number,
     maxAntlersStatementsPerLine: number,
     endNewline: boolean

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -98,6 +98,7 @@ export class Transformer {
 
         this.options = {
             tabSize: 4,
+            insertSpaces: true,
             newlinesAfterFrontMatter: 1,
             maxAntlersStatementsPerLine: 3,
             endNewline: true
@@ -1034,7 +1035,7 @@ export class Transformer {
 
         for (const [slug, comment] of this.inlineComments) {
             const open = this.selfClosing(slug),
-                commentResult = await CommentPrinter.printCommentAsync(comment, this.options.tabSize, 0, this.asyncInlineFormatter);
+                commentResult = await CommentPrinter.printCommentAsync(comment, this.options.tabSize, '', this.options.insertSpaces, this.asyncInlineFormatter);
 
             value = value.replace(open, commentResult);
         }
@@ -1043,7 +1044,7 @@ export class Transformer {
             const structure = this.blockComments[i];
 
             const comment = structure.node as AntlersNode,
-                commentResult = await CommentPrinter.printCommentAsync(comment, this.options.tabSize, this.indentLevel(structure.pairOpen), this.asyncInlineFormatter);
+                commentResult = await CommentPrinter.printCommentAsync(comment, this.options.tabSize, this.indentWhitespace(structure.pairOpen), this.options.insertSpaces, this.asyncInlineFormatter);
 
             value = value.replace(structure.pairOpen, commentResult);
             this.removeLines.push(structure.pairClose);
@@ -1058,14 +1059,14 @@ export class Transformer {
 
         this.inlineComments.forEach((comment, slug) => {
             const open = this.selfClosing(slug),
-                commentResult = CommentPrinter.printComment(comment, this.options.tabSize, 0, this.inlineFormatter);
+                commentResult = CommentPrinter.printComment(comment, this.options.tabSize, '', this.options.insertSpaces, this.inlineFormatter);
 
             value = value.replace(open, commentResult);
         });
 
         this.blockComments.forEach((structure) => {
             const comment = structure.node as AntlersNode,
-                commentResult = CommentPrinter.printComment(comment, this.options.tabSize, this.indentLevel(structure.pairOpen), this.inlineFormatter);
+                commentResult = CommentPrinter.printComment(comment, this.options.tabSize, this.indentWhitespace(structure.pairOpen), this.options.insertSpaces, this.inlineFormatter);
 
             value = value.replace(structure.pairOpen, commentResult);
             this.removeLines.push(structure.pairClose);
@@ -1137,6 +1138,18 @@ export class Transformer {
         });
 
         return result;
+    }
+
+    private indentWhitespace(value: string): string {
+        for (let i = 0; i < this.structureLines.length; i++) {
+            const thisLine = this.structureLines[i];
+
+            if (thisLine.includes(value)) {
+                return (/^[\t ]*/.exec(thisLine) ?? [''])[0];
+            }
+        }
+
+        return '';
     }
 
     private indentLevel(value: string, includeIndex = false): number {

--- a/server/src/runtime/lexer/antlersLexer.ts
+++ b/server/src/runtime/lexer/antlersLexer.ts
@@ -1079,6 +1079,22 @@ export class AntlersLexer {
                     continue;
                 }
 
+                if (this.cur == DocumentParser.Punctuation_Question && this.next == DocumentParser.Punctuation_Question &&
+                    this.chars[this.currentIndex + 2] == DocumentParser.Punctuation_Question) {
+                    // ???
+                    const nullCoalesceOperator = new NullCoalesceOperator();
+                    nullCoalesceOperator.isVirtual = false;
+                    nullCoalesceOperator.content = '???';
+                    nullCoalesceOperator.startPosition = node._lexerRelativeOffset(this.currentIndex);
+                    nullCoalesceOperator.endPosition = node._lexerRelativeOffset(this.currentIndex + 3);
+                    nullCoalesceOperator.parent = this.activeNode;
+
+                    this.runtimeNodes.push(nullCoalesceOperator);
+                    this.lastNode = nullCoalesceOperator;
+                    this.currentIndex += 2;
+                    continue;
+                }
+
                 if (this.cur == DocumentParser.Punctuation_Question && this.next == DocumentParser.Punctuation_Question) {
                     // ??
                     const nullCoalesceOperator = new NullCoalesceOperator();

--- a/server/src/runtime/nodes/abstractNode.ts
+++ b/server/src/runtime/nodes/abstractNode.ts
@@ -924,6 +924,7 @@ export class EscapedContentNode extends AntlersNode {
 export class ParameterNode extends AbstractNode {
     public modifier: IModifier | null = null;
     public isModifierParameter = false;
+    public isShorthand = false;
     public nameDelimiter:string|null = '"';
     public isVariableReference = false;
     public name = "";

--- a/server/src/runtime/parser/antlersNodeParser.ts
+++ b/server/src/runtime/parser/antlersNodeParser.ts
@@ -401,6 +401,58 @@ export class AntlersNodeParser {
                 ignorePrevious = false;
             }
 
+            if (hasFoundName == false && i >= parseContentOffset &&
+                current == DocumentParser.Punctuation_Colon && next == '$' &&
+                (prev == null || StringUtilities.ctypeSpace(prev))) {
+                let shorthandEnd = i + 2;
+
+                while (shorthandEnd < charCount &&
+                    !StringUtilities.ctypeSpace(chars[shorthandEnd]) && chars[shorthandEnd] != '/') {
+                    shorthandEnd += 1;
+                }
+
+                const shorthandName = chars.slice(i + 2, shorthandEnd).join('');
+
+                if (shorthandName.length > 0) {
+                    const parameterNode = new ParameterNode(),
+                        valueStart = i + 2,
+                        valueEnd = shorthandEnd - 1;
+
+                    parameterNode.isShorthand = true;
+                    parameterNode.isVariableReference = true;
+                    parameterNode.hasValidValueDelimiter = false;
+                    parameterNode.nameDelimiter = null;
+                    parameterNode.name = shorthandName;
+                    parameterNode.value = shorthandName;
+                    parameterNode.parent = node;
+                    parameterNode.startPosition = node.relativePositionFromOffset(i + 1, i + 1) ?? null;
+                    parameterNode.endPosition = node.relativePositionFromOffset(shorthandEnd + 1, shorthandEnd + 1) ?? null;
+                    parameterNode.blockPosition = {
+                        start: node.relativeOffset(i, i) ?? null,
+                        end: node.relativeOffset(valueEnd, valueEnd) ?? null
+                    };
+                    parameterNode.namePosition = {
+                        start: node.relativeOffset(valueStart, valueStart) ?? null,
+                        end: node.relativeOffset(valueEnd, valueEnd) ?? null
+                    };
+                    parameterNode.valuePosition = {
+                        start: node.relativeOffset(valueStart, valueStart) ?? null,
+                        end: node.relativeOffset(valueEnd, valueEnd) ?? null
+                    };
+
+                    parameters.push(parameterNode);
+                    i = shorthandEnd - 1;
+                    currentChars = [];
+                    blockStartAt = -1;
+                    blockEndAt = -1;
+                    nameBlockStartAt = -1;
+                    nameBlockEndAt = -1;
+                    valueBlockStartAt = -1;
+                    valueBlockEndAt = -1;
+                    continue;
+                }
+            }
+
             if (hasFoundName == false && StringUtilities.ctypeSpace(current)) {
                 // Flush the buffer.
                 currentChars = [];

--- a/server/src/runtime/parser/documentParser.ts
+++ b/server/src/runtime/parser/documentParser.ts
@@ -730,13 +730,18 @@ export class DocumentParser {
             }
         }
 
-        if (!this.isNoParse && this.nodes.length > 0) {
-            const lastCoveredOffset = this.nodes.reduce((offset, node) => {
-                    return Math.max(offset, node.endPosition?.offset ?? -1);
+        if (!this.isNoParse && !this.doesHaveUnclosedStructures && this.nodes.length > 0) {
+            const lastNode = this.nodes[this.nodes.length - 1],
+                lastLiteralContent = lastNode instanceof LiteralNode
+                    ? lastNode.sourceContent || lastNode.content
+                    : '',
+                hasTrailingLiteral = lastLiteralContent.length > 0 && this.content.endsWith(lastLiteralContent),
+                lastCoveredIndex = this.nodes.reduce((index, node) => {
+                    return Math.max(index, node.endPosition?.index ?? -1);
                 }, -1),
-                literalStart = lastCoveredOffset + 1;
+                literalStart = lastCoveredIndex + 1;
 
-            if (literalStart < this.inputLen) {
+            if (!hasTrailingLiteral && literalStart < this.inputLen) {
                 const literalNode = new LiteralNode(),
                     literalContent = this.content.substring(literalStart);
 

--- a/server/src/runtime/parser/documentParser.ts
+++ b/server/src/runtime/parser/documentParser.ts
@@ -730,6 +730,28 @@ export class DocumentParser {
             }
         }
 
+        if (!this.isNoParse && this.nodes.length > 0) {
+            const lastCoveredOffset = this.nodes.reduce((offset, node) => {
+                    return Math.max(offset, node.endPosition?.offset ?? -1);
+                }, -1),
+                literalStart = lastCoveredOffset + 1;
+
+            if (literalStart < this.inputLen) {
+                const literalNode = new LiteralNode(),
+                    literalContent = this.content.substring(literalStart);
+
+                literalNode.withParser(this);
+                literalNode.content = this.prepareLiteralContent(literalContent);
+
+                if (literalNode.content.length > 0) {
+                    literalNode.startPosition = this.positionFromOffset(literalStart, literalStart);
+                    literalNode.endPosition = this.positionFromOffset(this.inputLen - 1, this.inputLen - 1);
+                    literalNode.sourceContent = literalContent;
+                    this.nodes.push(literalNode);
+                }
+            }
+        }
+
         let index = 0;
 
         this.nodes.forEach((node) => {

--- a/server/src/test/basic_node.test.ts
+++ b/server/src/test/basic_node.test.ts
@@ -281,6 +281,17 @@ suite("Basic Node Test", () => {
         assert.strictEqual(nodes[1].content, "<p>I am a literal.</p>");
     });
 
+    test("interpolated parameters dont skip trailing literal nodes", () => {
+        const nodes = parseNodes(
+            '{{ partial:navigation/tabs tab_parent_url="{{ url }}" tab_parent_title="{{ tabname }}" }}\n<!-- End: partial -->'
+        );
+
+        assertCount(2, nodes);
+        assertInstanceOf(AntlersNode, nodes[0]);
+        assertInstanceOf(LiteralNode, nodes[1]);
+        assert.strictEqual(nodes[1].content, "\n<!-- End: partial -->");
+    });
+
     test("neighboring comments dont confuse things", () => {
         const template = `{{# A comment #}}
 		{{# another comment {{ width }} #}}

--- a/server/src/test/basic_node.test.ts
+++ b/server/src/test/basic_node.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./testUtils/assertions.js";
 import { getParsedRuntimeNodes, parseNodes } from "./testUtils/parserUtils.js";
 import EnvironmentDetails from "../runtime/runtime/environmentDetails.js";
-import { AntlersNode, LiteralNode, SemanticGroup, VariableNode, LogicGroup, EqualCompOperator, ModifierNode, PathNode, VariableReference } from '../runtime/nodes/abstractNode.js';
+import { AntlersNode, LiteralNode, SemanticGroup, VariableNode, LogicGroup, EqualCompOperator, ModifierNode, PathNode, VariableReference, NullCoalesceOperator } from '../runtime/nodes/abstractNode.js';
 
 suite("Basic Node Test", () => {
     test("it returns nodes", () => {
@@ -28,6 +28,15 @@ suite("Basic Node Test", () => {
             toAntlers(nodes[0]).getContent(),
             ' meta_title ?? title ?? "No Title Set" '
         );
+    });
+
+    test("it lexes the triple fallback operator as one token", () => {
+        const nodes = parseNodes("{{ a ??? b }}"),
+            antlersNode = toAntlers(nodes[0]);
+
+        assertCount(3, antlersNode.runtimeNodes);
+        assertInstanceOf(NullCoalesceOperator, antlersNode.runtimeNodes[1]);
+        assert.strictEqual(antlersNode.runtimeNodes[1].content, "???");
     });
 
     test("it removes params from node content", () => {

--- a/server/src/test/basic_node.test.ts
+++ b/server/src/test/basic_node.test.ts
@@ -301,6 +301,15 @@ suite("Basic Node Test", () => {
         assert.strictEqual(nodes[1].content, "\n<!-- End: partial -->");
     });
 
+    test("interpolated parameters dont duplicate existing trailing literals", () => {
+        const nodes = parseNodes('{{ partial:x parameter="{{ value }}" }}tail');
+
+        assertCount(2, nodes);
+        assertInstanceOf(AntlersNode, nodes[0]);
+        assertInstanceOf(LiteralNode, nodes[1]);
+        assert.strictEqual(nodes[1].content, "tail");
+    });
+
     test("neighboring comments dont confuse things", () => {
         const template = `{{# A comment #}}
 		{{# another comment {{ width }} #}}

--- a/server/src/test/formatter_basic_nodes.test.ts
+++ b/server/src/test/formatter_basic_nodes.test.ts
@@ -9,6 +9,21 @@ function assertFormattedMatches(input: string, expected: string) {
 }
 
 suite("Document Formatting Test", () => {
+    test('multiline PHP formatting is idempotent', () => {
+        const template = `{{# Extract Youtube Video ID #}}
+{{?
+preg_match('/(?:youtube\\.com\\/.*v=|youtu\\.be\\/|youtube\\.com\\/embed\\/)([^&\\/\\?\\#]+)/', $video_link, $matches);
+$videoId = $matches[1] ?? null;
+?}}`;
+
+        let output = template;
+
+        for (let i = 0; i < 5; i++) {
+            output = formatAntlers(output);
+            assert.strictEqual(output, template);
+        }
+    });
+
     test('it doesnt remove variable parts with neighboring numeric nodes', () => {
         assert.strictEqual(formatAntlers('{{ assets:0 }}'), '{{ assets:0 }}');
         assert.strictEqual(formatAntlers('{{ assets:0:0 }}'), '{{ assets:0:0 }}');

--- a/server/src/test/formatter_comments.test.ts
+++ b/server/src/test/formatter_comments.test.ts
@@ -51,4 +51,45 @@ suite('Formatter Comments', () => {
 {{# {{ partial src="default" }} #}}`;
         assert.strictEqual(formatAntlers(input).trim(), expected);
     });
+
+    test('tab-indented comments remain stable', () => {
+        const input = [
+            '<div>',
+            '\t<div>',
+            '\t\t{{#',
+            '            @name Button',
+            '\t\t\t@param href Creates a link',
+            '                - nested detail',
+            '\t\t#}}',
+            '\t</div>',
+            '</div>'
+        ].join('\n');
+        const expected = [
+            '<div>',
+            '\t<div>',
+            '\t\t{{#',
+            '\t\t\t@name Button',
+            '\t\t\t@param href Creates a link',
+            '\t\t\t\t- nested detail',
+            '\t\t#}}',
+            '\t</div>',
+            '</div>'
+        ].join('\n');
+        const options = {
+            htmlOptions: { wrapLineLength: 500 },
+            tabSize: 4,
+            insertSpaces: false,
+            formatFrontMatter: true,
+            maxStatementsPerLine: 3,
+            formatExtensions: []
+        };
+
+        let result = formatAntlers(input, options);
+        assert.strictEqual(result, expected);
+
+        for (let i = 0; i < 5; i++) {
+            result = formatAntlers(result, options);
+            assert.strictEqual(result, expected);
+        }
+    });
 });

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -2,6 +2,23 @@ import assert from 'assert';
 import { formatAntlers } from './testUtils/formatAntlers.js';
 
 suite('Formatter Operators', () => {
+    test('it preserves automatic statement boundaries', () => {
+        const input = `{{ text = 'one'
+number = 2
+enabled = true
+source = other
+source }}`,
+            expected = `{{ text = 'one'
+ number = 2
+ enabled = true
+ source = other
+ source }}`,
+            firstPass = formatAntlers(input);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass), firstPass);
+    });
+
     test('it wraps multiple language operators', () => {
         const template = `
         {{ test = one merge two 

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -119,6 +119,10 @@ suite('Formatter Operators', () => {
         assert.strictEqual(formatAntlers('{{ left   ??     right }}'), '{{ left ?? right }}');
     });
 
+    test('it emits ???', () => {
+        assert.strictEqual(formatAntlers('{{ left   ???     right }}'), '{{ left ??? right }}');
+    });
+
     test('it emits ?:', () => {
         assert.strictEqual(formatAntlers('{{ left   ?:     right }}'), '{{ left ?: right }}');
     });

--- a/server/src/test/formatter_prettier_basic_nodes.test.ts
+++ b/server/src/test/formatter_prettier_basic_nodes.test.ts
@@ -2,6 +2,23 @@ import assert from 'assert';
 import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
 
 suite('Prettier Formatter Basic Nodes', () => {
+    test('it preserves automatic statement boundaries', async () => {
+        const input = `{{ text = 'one'
+number = 2
+enabled = true
+source = other
+source }}`,
+            expected = `{{ text = 'one'
+ number = 2
+ enabled = true
+ source = other
+ source }}`,
+            firstPass = await formatStringWithPrettier(input);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatStringWithPrettier(firstPass), firstPass);
+    });
+
     test('it preserves the triple fallback operator', async () => {
         assert.strictEqual((await formatStringWithPrettier('{{ a ??? b }}')).trim(), '{{ a ??? b }}');
     });

--- a/server/src/test/formatter_prettier_basic_nodes.test.ts
+++ b/server/src/test/formatter_prettier_basic_nodes.test.ts
@@ -2,6 +2,10 @@ import assert from 'assert';
 import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
 
 suite('Prettier Formatter Basic Nodes', () => {
+    test('it preserves the triple fallback operator', async () => {
+        assert.strictEqual((await formatStringWithPrettier('{{ a ??? b }}')).trim(), '{{ a ??? b }}');
+    });
+
     test('it doesnt remove variable parts with neighboring numeric nodes', async () => {
         assert.strictEqual((await formatStringWithPrettier('{{ assets:0 }}')).trim(), '{{ assets:0 }}');
         assert.strictEqual((await formatStringWithPrettier('{{ assets:0:0 }}')).trim(), '{{ assets:0:0 }}');

--- a/server/src/test/formatter_prettier_comments.test.ts
+++ b/server/src/test/formatter_prettier_comments.test.ts
@@ -145,4 +145,38 @@ suite('Formatter Prettier Comments', () => {
                 assert.strictEqual(res, expected);
             }
     });
+
+    test('tab-indented comments remain stable', async () => {
+        const input = [
+            '<div>',
+            '\t<div>',
+            '\t\t{{#',
+            '            @name Button',
+            '\t\t\t@param href Creates a link',
+            '                - nested detail',
+            '\t\t#}}',
+            '\t</div>',
+            '</div>'
+        ].join('\n');
+        const expected = [
+            '<div>',
+            '\t<div>',
+            '\t\t{{#',
+            '\t\t\t@name Button',
+            '\t\t\t@param href Creates a link',
+            '\t\t\t\t- nested detail',
+            '\t\t#}}',
+            '\t</div>',
+            '</div>'
+        ].join('\n');
+        const options = { useTabs: true, tabWidth: 4 };
+
+        let result = (await formatStringWithPrettier(input, options)).trimEnd();
+        assert.strictEqual(result, expected);
+
+        for (let i = 0; i < 5; i++) {
+            result = (await formatStringWithPrettier(result, options)).trimEnd();
+            assert.strictEqual(result, expected);
+        }
+    });
 });

--- a/server/src/test/formatter_prettier_php.test.ts
+++ b/server/src/test/formatter_prettier_php.test.ts
@@ -2,6 +2,20 @@ import assert from 'assert';
 import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
 
 suite('Formatter Prettier PHP', () => {
+    test('multiline PHP formatting is idempotent', async () => {
+        const template = `{{# Extract Youtube Video ID #}}
+{{?
+preg_match('/(?:youtube\\.com\\/.*v=|youtu\\.be\\/|youtube\\.com\\/embed\\/)([^&\\/\\?\\#]+)/', $video_link, $matches);
+$videoId = $matches[1] ?? null;
+?}}`;
+
+        const once = await formatStringWithPrettier(template),
+            twice = await formatStringWithPrettier(once);
+
+        assert.strictEqual(twice, once);
+        assert.ok(once.endsWith('?}}\n'));
+    });
+
     test('it can format PHP nodes', async () => {
         assert.strictEqual(
             (await formatStringWithPrettier(`

--- a/server/src/test/formatter_prettier_tags.test.ts
+++ b/server/src/test/formatter_prettier_tags.test.ts
@@ -156,6 +156,18 @@ After Partial
         assert.strictEqual((await formatStringWithPrettier(template)).trim(), output);
     });
 
+    test('it preserves quoted shorthand modifier values', async () => {
+        const inputs = [
+            `{{ values | join:', ' }}`,
+            `{{ title | modifier:'hello world' }}`,
+            `{{ title | modifier:"hello :|" }}`
+        ];
+
+        for (const input of inputs) {
+            assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
+        }
+    });
+
     test('it formats inline antlers nodes', async () => {
         const template = `<{{ as or 'a' }}  
 {{ slot:attributes }}

--- a/server/src/test/formatter_prettier_tags.test.ts
+++ b/server/src/test/formatter_prettier_tags.test.ts
@@ -180,4 +180,12 @@ style="
         
         assert.strictEqual(out, expected);
     });
+
+    test('it preserves content after interpolated parameters', async () => {
+        const template = `<!-- /page_builder/_tab_page_child_nav.antlers.html -->
+{{ partial:navigation/tabs tab_parent_url="{{ url }}" tab_parent_title="{{ tabname }}" }}
+<!-- End: /page_builder/_tab_page_child_nav.antlers.html -->`;
+
+        assert.strictEqual((await formatStringWithPrettier(template)).trim(), template);
+    });
 });

--- a/server/src/test/formatter_prettier_tags.test.ts
+++ b/server/src/test/formatter_prettier_tags.test.ts
@@ -2,6 +2,12 @@ import assert from 'assert';
 import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
 
 suite('Formatter Prettier Tags', () => {   
+    test('it preserves shorthand parameters', async () => {
+        const template = '{{ partial:file/to/partial limit="5" :$shorthandVariable offset="1" }}';
+
+        assert.strictEqual((await formatStringWithPrettier(template)).trim(), template);
+    });
+
     test('it respects parameter node value delimiters', async () => {
         const input = `{{ partial:components/button as="button" 				label="{ trans:strings.form_send }" 
                                     attribute='x-bind:disabled="sending" x-bind:class="&#123;&#39;opacity-25 cursor-default&#39;: sending&#125;"' }}`;

--- a/server/src/test/formatter_tags.test.ts
+++ b/server/src/test/formatter_tags.test.ts
@@ -2,6 +2,12 @@ import assert from 'assert';
 import { formatAntlers } from './testUtils/formatAntlers.js';
 
 suite('Formatter Tags', () => {   
+    test('it preserves shorthand parameters', () => {
+        const template = '{{ partial:file/to/partial limit="5" :$shorthandVariable offset="1" }}';
+
+        assert.strictEqual(formatAntlers(template), template);
+    });
+
     test('it respects parameter node value delimiters', () => {
         const input = `{{ partial:components/button as="button" 				label="{ trans:strings.form_send }" 
                                     attribute='x-bind:disabled="sending" x-bind:class="&#123;&#39;opacity-25 cursor-default&#39;: sending&#125;"' }}`;

--- a/server/src/test/formatter_tags.test.ts
+++ b/server/src/test/formatter_tags.test.ts
@@ -159,6 +159,16 @@ After Partial
         assert.strictEqual(formatAntlers(input), input);
     });
 
+    test('it preserves quoted shorthand modifier values', () => {
+        const inputs = [
+            `{{ values | join:', ' }}`,
+            `{{ title | modifier:'hello world' }}`,
+            `{{ title | modifier:"hello :|" }}`
+        ];
+
+        inputs.forEach((input) => assert.strictEqual(formatAntlers(input), input));
+    });
+
     test('it doesnt duplicate array values with strings', () => {
         assert.strictEqual(formatAntlers(`{{ view:background['default'] }}`).trim(), `{{ view:background['default'] }}`);
         assert.strictEqual(formatAntlers(`{{ not_view:background['default'] }}`).trim(), `{{ not_view:background['default'] }}`);

--- a/server/src/test/node_parameters.test.ts
+++ b/server/src/test/node_parameters.test.ts
@@ -60,6 +60,19 @@ suite("Node Parameters Test", () => {
         assertTrue(param1.isVariableReference);
     });
 
+    test("shorthand variable references are parsed", () => {
+        const nodes = parseNodes('{{ partial:file/to/partial limit="5" :$shorthandVariable offset="1" }}'),
+            node = toAntlers(nodes[0]);
+
+        assertCount(3, node.parameters);
+
+        const shorthand = node.parameters[1];
+
+        assertTrue(shorthand.isShorthand);
+        assertTrue(shorthand.isVariableReference);
+        assertParameterNameValue(shorthand, "shorthandVariable", "shorthandVariable");
+    });
+
     test("equals followed by space is not a parameter", () => {
         const nodes = parseNodes(
             "{{ is_current || is_parent ?= 'font-medium text-gray-800' }}"


### PR DESCRIPTION
## Summary

- preserve trailing content after nested parameter interpolation
- keep triple fallback operators intact
- preserve shorthand variable parameters
- cover multiline PHP idempotence
- preserve automatic source-line statement boundaries without breaking continued operators, ternaries, modifiers, or arrays
- retain quotes and exact contents for shorthand modifier values
- normalize multiline comment indentation to the selected spaces or tabs style
- preserve relative indentation inside comments without drift across repeated formatting

## Verification

- branch test manifest: 301 passing
- 60-case core/Prettier statement and modifier audit: passing
- 60-case comment indentation matrix across five consecutive passes: passing
- formatter CLI statement, quote, and comment smokes: passing
- repeated formatting remains stable
- `git diff --check`: clean

Fixes #116
Fixes #115
Fixes #100
Fixes #99
Fixes #98