### PR TITLE
Harden project file scanning

### DIFF
--- a/server/src/projects/fileSystemProvider/fileScanner.ts
+++ b/server/src/projects/fileSystemProvider/fileScanner.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+function getEntryStats(fileName: string): fs.Stats | null {
+    try {
+        const linkStats = fs.lstatSync(fileName);
+
+        if (linkStats.isSymbolicLink()) {
+            const targetStats = fs.statSync(fileName);
+
+            if (targetStats.isDirectory()) {
+                return null;
+            }
+
+            return targetStats;
+        }
+
+        return linkStats;
+    } catch (_error) {
+        return null;
+    }
+}
+
+function getDirectoryEntries(startPath: string): string[] {
+    try {
+        if (!fs.statSync(startPath).isDirectory()) {
+            return [];
+        }
+
+        return fs.readdirSync(startPath);
+    } catch (_error) {
+        return [];
+    }
+}
+
+export function getFiles(startPath: string, filter: string, foundFiles: string[] = []): string[] {
+    const files = getDirectoryEntries(startPath);
+
+    for (let i = 0; i < files.length; i++) {
+        const filename = path.join(startPath, files[i]),
+            stat = getEntryStats(filename);
+
+        if (stat == null) {
+            continue;
+        }
+
+        if (stat.isDirectory()) {
+            getFiles(filename, filter, foundFiles);
+        } else if (stat.isFile() && filename.includes(filter)) {
+            foundFiles.push(filename);
+        }
+    }
+
+    return [...new Set(foundFiles)];
+}
+
+export function getDirectFiles(startPath: string, filter: string): string[] {
+    const returnFiles: string[] = [],
+        files = getDirectoryEntries(startPath);
+
+    for (let i = 0; i < files.length; i++) {
+        const filename = path.join(startPath, files[i]),
+            stat = getEntryStats(filename);
+
+        if (stat?.isFile() && filename.includes(filter)) {
+            returnFiles.push(filename);
+        }
+    }
+
+    return [...new Set(returnFiles)];
+}

--- a/server/src/projects/fileSystemProvider/fileSystemStatamicProject.ts
+++ b/server/src/projects/fileSystemProvider/fileSystemStatamicProject.ts
@@ -35,6 +35,7 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';;
 import { StringUtilities } from '../../runtime/utilities/stringUtilities.js';
 import { makeTagDoc } from '../../documentation/utils.js';
 import PackageManager from '../../marketplace/packageManager.js';
+import { getDirectFiles, getFiles } from './fileScanner.js';
 
 function getRootProjectPath(path: string): string {
     const parts = normalizePath(path).split("/");
@@ -152,64 +153,6 @@ function makeTaxonomyTermsDirectory(root: string): string {
 
 function makeNavigationDirectory(root: string): string {
     return makeContentDirectory(root) + "navigation/";
-}
-
-function getFiles(
-    startPath: string,
-    filter: string,
-    foundFiles: string[]
-): string[] {
-    if (!fs.existsSync(startPath)) {
-        return [];
-    }
-
-    const fStats = fs.statSync(startPath);
-
-    if (!fStats.isDirectory()) {
-        return [];
-    }
-
-    let returnFiles = foundFiles || [];
-    const files = fs.readdirSync(startPath);
-
-    for (let i = 0; i < files.length; i++) {
-        const filename = path.join(startPath, files[i]);
-        const stat = fs.lstatSync(filename);
-
-        if (stat.isDirectory()) {
-            returnFiles = returnFiles.concat(getFiles(filename, filter, foundFiles));
-        } else if (filename.indexOf(filter) >= 0) {
-            returnFiles.push(filename);
-        }
-    }
-
-    return [...new Set(returnFiles)];
-}
-
-function getDirectFiles(startPath: string, filter: string): string[] {
-    if (!fs.existsSync(startPath)) {
-        return [];
-    }
-
-    const fStats = fs.statSync(startPath);
-
-    if (!fStats.isDirectory()) {
-        return [];
-    }
-
-    const returnFiles = [];
-    const files = fs.readdirSync(startPath);
-
-    for (let i = 0; i < files.length; i++) {
-        const filename = path.join(startPath, files[i]);
-        const stat = fs.lstatSync(filename);
-
-        if (stat.isDirectory() == false) {
-            returnFiles.push(filename);
-        }
-    }
-
-    return [...new Set(returnFiles)];
 }
 
 function getProjectViews(viewPath: string): IView[] {

--- a/server/src/test/project_file_scanner.test.ts
+++ b/server/src/test/project_file_scanner.test.ts
@@ -1,0 +1,86 @@
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getDirectFiles, getFiles } from '../projects/fileSystemProvider/fileScanner.js';
+
+function removeDirectory(directory: string) {
+    fs.readdirSync(directory).forEach((entry) => {
+        const entryPath = path.join(directory, entry),
+            stat = fs.lstatSync(entryPath);
+
+        if (stat.isDirectory() && !stat.isSymbolicLink()) {
+            removeDirectory(entryPath);
+        } else {
+            fs.unlinkSync(entryPath);
+        }
+    });
+    fs.rmdirSync(directory);
+}
+
+suite('Project File Scanner', () => {
+    let tempDirectory = '';
+
+    setup(() => {
+        tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'antlers-scanner-'));
+    });
+
+    teardown(() => {
+        removeDirectory(tempDirectory);
+    });
+
+    test('directory symlinks are skipped safely', () => {
+        const viewsDirectory = path.join(tempDirectory, 'views'),
+            linkedDirectory = path.join(tempDirectory, 'linked-views'),
+            symlinkPath = path.join(viewsDirectory, 'linked.html');
+
+        fs.mkdirSync(viewsDirectory);
+        fs.mkdirSync(linkedDirectory);
+        fs.writeFileSync(path.join(viewsDirectory, 'local.antlers.html'), 'local');
+        fs.writeFileSync(path.join(linkedDirectory, 'linked.antlers.html'), 'linked');
+        fs.symlinkSync(linkedDirectory, symlinkPath, process.platform == 'win32' ? 'junction' : 'dir');
+
+        assert.deepStrictEqual(
+            getFiles(viewsDirectory, '.html'),
+            [path.join(viewsDirectory, 'local.antlers.html')]
+        );
+    });
+
+    test('broken entries do not stop scanning', () => {
+        const viewsDirectory = path.join(tempDirectory, 'views'),
+            brokenPath = path.join(viewsDirectory, 'broken');
+
+        fs.mkdirSync(viewsDirectory);
+        fs.writeFileSync(path.join(viewsDirectory, 'local.antlers.html'), 'local');
+        fs.symlinkSync(
+            path.join(tempDirectory, 'missing'),
+            brokenPath,
+            process.platform == 'win32' ? 'junction' : 'dir'
+        );
+
+        assert.deepStrictEqual(
+            getFiles(viewsDirectory, '.html'),
+            [path.join(viewsDirectory, 'local.antlers.html')]
+        );
+    });
+
+    test('direct scans respect the requested filter', () => {
+        const linkedDirectory = path.join(tempDirectory, 'linked-files');
+
+        fs.writeFileSync(path.join(tempDirectory, 'collection.yaml'), 'title: Collection');
+        fs.writeFileSync(path.join(tempDirectory, 'notes.txt'), 'notes');
+        fs.mkdirSync(path.join(tempDirectory, 'nested'));
+        fs.writeFileSync(path.join(tempDirectory, 'nested', 'nested.yaml'), 'title: Nested');
+        fs.mkdirSync(linkedDirectory);
+        fs.symlinkSync(
+            linkedDirectory,
+            path.join(tempDirectory, 'linked.yaml'),
+            process.platform == 'win32' ? 'junction' : 'dir'
+        );
+
+        assert.deepStrictEqual(
+            getDirectFiles(tempDirectory, '.yaml'),
+            [path.join(tempDirectory, 'collection.yaml')]
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- skip directory symlinks during recursive and direct project scans
- tolerate broken or inaccessible filesystem entries
- apply requested file filters during direct scans

## Tests

- `npm run compile`
- project scanner regressions on Windows, including a real directory junction
- full server test manifest: 287 passing

Fixes #110