### PR TITLE
Flag invalid else-if syntax

### DIFF
--- a/server/src/diagnostics/handlers/coreHandlers.ts
+++ b/server/src/diagnostics/handlers/coreHandlers.ts
@@ -1,6 +1,7 @@
 import { IDiagnosticsHandler } from '../diagnosticsHandler.js';
 import DataDumpHandler from './dataDumpHandler.js';
 import DeprecatedModifierHandler from './deprecatedModifierHandler.js';
+import ElseIfSyntaxHandler from './elseIfSyntaxHandler.js';
 import FieldTypeModifierSequenceHandler from './fieldTypeModifierSequenceHandler.js';
 import InterleavedNodeHandler from './interleavedNodes.js';
 import InvalidParameterHandler from './invalidParameterHandler.js';
@@ -20,6 +21,7 @@ const CoreHandlers: IDiagnosticsHandler[] = [
     ModifierRuntimeTypeHandler,
     FieldTypeModifierSequenceHandler,
     DeprecatedModifierHandler,
+    ElseIfSyntaxHandler,
     RelateTagHandler,
     TagsThatErrorHandler,
     ShorthandModifierHandler,

--- a/server/src/diagnostics/handlers/elseIfSyntaxHandler.ts
+++ b/server/src/diagnostics/handlers/elseIfSyntaxHandler.ts
@@ -1,0 +1,20 @@
+import { AntlersError } from '../../runtime/errors/antlersError.js';
+import { AntlersErrorCodes } from '../../runtime/errors/antlersErrorCodes.js';
+import { AntlersNode } from '../../runtime/nodes/abstractNode.js';
+import { IDiagnosticsHandler } from '../diagnosticsHandler.js';
+
+const ElseIfSyntaxHandler: IDiagnosticsHandler = {
+    checkNode(node: AntlersNode) {
+        if (node.runtimeName() != 'else' || !/^else\s+if\b/.test(node.getContent().trim())) {
+            return [];
+        }
+
+        return [AntlersError.makeSyntaxError(
+            AntlersErrorCodes.LINT_ELSE_IF_SYNTAX,
+            node,
+            'Use `elseif` instead of `else if`.'
+        )];
+    }
+};
+
+export default ElseIfSyntaxHandler;

--- a/server/src/runtime/errors/antlersErrorCodes.ts
+++ b/server/src/runtime/errors/antlersErrorCodes.ts
@@ -164,4 +164,5 @@ export class AntlersErrorCodes {
     static readonly LINT_SELECT_FIELD_JOIN_RAW = 'ANTLR_523';
     static readonly LINT_INVALID_PARAMETER_VALUE_DELIMITER = 'ANTLR_524';
     static readonly LINT_MODIFIERS_ON_QUERY_BUILDERS_REQUIRE_AS = 'ANTLR_525';
+    static readonly LINT_ELSE_IF_SYNTAX = 'ANTLR_526';
 }

--- a/server/src/test/diagnostics_else_if.test.ts
+++ b/server/src/test/diagnostics_else_if.test.ts
@@ -1,0 +1,77 @@
+import assert from 'assert';
+import { AntlersSettings } from '../antlersSettings.js';
+import CoreHandlers from '../diagnostics/handlers/coreHandlers.js';
+import ElseIfSyntaxHandler from '../diagnostics/handlers/elseIfSyntaxHandler.js';
+import { AntlersDocument } from '../runtime/document/antlersDocument.js';
+import { ErrorLevel } from '../runtime/errors/antlersError.js';
+import { AntlersErrorCodes } from '../runtime/errors/antlersErrorCodes.js';
+
+const settings: AntlersSettings = {
+    formatFrontMatter: false,
+    showGeneralSnippetCompletions: true,
+    diagnostics: {
+        warnOnDynamicCssClassNames: true,
+        validateTagParameters: true,
+        reportDiagnostics: true
+    },
+    trace: { server: 'off' },
+    formatterIgnoreExtensions: [],
+    languageVersion: 'runtime'
+};
+
+function getBranchNode(template: string, runtimeName: string) {
+    return AntlersDocument.fromText(template)
+        .getAllAntlersNodes()
+        .find((node) => node.runtimeName() == runtimeName);
+}
+
+suite('Else If Diagnostics', () => {
+    test('the handler is registered', () => {
+        assert.strictEqual(CoreHandlers.includes(ElseIfSyntaxHandler), true);
+    });
+
+    test('else if is reported as invalid syntax', () => {
+        const node = getBranchNode(
+            '{{ if test }}\n{{ else if not_test }}\n{{ /if }}',
+            'else'
+        );
+
+        assert.notStrictEqual(node, undefined);
+
+        const errors = ElseIfSyntaxHandler.checkNode(node!, settings);
+
+        assert.strictEqual(errors.length, 1);
+        assert.strictEqual(errors[0].errorCode, AntlersErrorCodes.LINT_ELSE_IF_SYNTAX);
+        assert.strictEqual(errors[0].message, 'Use `elseif` instead of `else if`.');
+        assert.strictEqual(errors[0].level, ErrorLevel.Error);
+        assert.strictEqual(errors[0].node, node);
+    });
+
+    test('whitespace variations are reported', () => {
+        for (const branch of ['else\tif not_test', 'else\nif not_test']) {
+            const node = getBranchNode(
+                `{{ if test }}\n{{ ${branch} }}\n{{ /if }}`,
+                'else'
+            );
+
+            assert.notStrictEqual(node, undefined);
+            assert.strictEqual(ElseIfSyntaxHandler.checkNode(node!, settings).length, 1);
+        }
+    });
+
+    test('valid branches and similar names are not reported', () => {
+        const templates = [
+            ['{{ if test }}\n{{ elseif not_test }}\n{{ /if }}', 'elseif'],
+            ['{{ if test }}\n{{ else }}\n{{ /if }}', 'else'],
+            ['{{ if test }}\n{{ else iffy }}\n{{ /if }}', 'else'],
+            ['{{ if test }}\n{{ else:index }}\n{{ /if }}', 'else:index']
+        ];
+
+        for (const [template, runtimeName] of templates) {
+            const node = getBranchNode(template, runtimeName);
+
+            assert.notStrictEqual(node, undefined);
+            assert.deepStrictEqual(ElseIfSyntaxHandler.checkNode(node!, settings), []);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- report `{{ else if ... }}` as invalid Antlers syntax
- suggest the supported `elseif` spelling
- avoid false positives for `elseif`, `else`, `else:index`, and similar names

## Tests

- `npm run compile`
- focused diagnostic registration, severity, whitespace, and false-positive regressions
- full server test manifest: 288 passing

Fixes #109