### PR TITLE
Fix partial src links

### DIFF
--- a/server/src/services/antlersLinks.ts
+++ b/server/src/services/antlersLinks.ts
@@ -1,7 +1,59 @@
 import { DocumentLink } from "vscode-languageserver-types";
+import { getViewName } from "../antlers/tags/core/partials/partialUtilities.js";
 import ProjectManager from '../projects/projectManager.js';
+import { IProjectDetailsProvider } from "../projects/projectDetailsProvider.js";
 import ReferenceManager from "../references/referenceManager.js";
+import { AntlersNode } from "../runtime/nodes/abstractNode.js";
 import { antlersPositionToVsCode } from '../utils/conversions.js';
+
+export function makePartialDocumentLink(node: AntlersNode, project: IProjectDetailsProvider): DocumentLink | null {
+    const viewName = getViewName(node);
+
+    if (viewName == null || viewName.length == 0) {
+        return null;
+    }
+
+    const srcParameter = node.findParameter("src");
+
+    if (!node.hasMethodPart() && (srcParameter == null || !srcParameter.containsSimpleValue())) {
+        return null;
+    }
+
+    const projectPartial = project.findRelativeView(viewName);
+
+    if (projectPartial == null) {
+        return null;
+    }
+
+    if (node.hasMethodPart()) {
+        const end = antlersPositionToVsCode(node.nameEndsOn);
+
+        return {
+            range: {
+                start: antlersPositionToVsCode(node.startPosition),
+                end: {
+                    character: end.character - 2,
+                    line: end.line
+                },
+            },
+            tooltip: "Partial: " + projectPartial.displayName,
+            target: decodeURIComponent(projectPartial.documentUri),
+        };
+    }
+
+    if (srcParameter?.valuePosition == null) {
+        return null;
+    }
+
+    return {
+        range: {
+            start: antlersPositionToVsCode(srcParameter.valuePosition.start),
+            end: antlersPositionToVsCode(srcParameter.valuePosition.end),
+        },
+        tooltip: "Partial: " + projectPartial.displayName,
+        target: decodeURIComponent(projectPartial.documentUri),
+    };
+}
 
 export class DocumentLinkManager {
     static getDocumentLinks(docPath: string): DocumentLink[] {
@@ -12,25 +64,10 @@ export class DocumentLinkManager {
 
             for (let i = 0; i < references.length; i++) {
                 const thisRef = references[i];
+                const documentLink = makePartialDocumentLink(thisRef, ProjectManager.instance.getStructure());
 
-                if (thisRef.hasMethodPart()) {
-                    const projectPartial = ProjectManager.instance.getStructure().findRelativeView(thisRef.getMethodNameValue());
-
-                    if (projectPartial != null) {
-                        const end = antlersPositionToVsCode(thisRef.nameEndsOn);
-
-                        documentLinks.push({
-                            range: {
-                                start: antlersPositionToVsCode(thisRef.startPosition),
-                                end: {
-                                    character: end.character - 2,
-                                    line: end.line
-                                },
-                            },
-                            tooltip: "Partial: " + projectPartial.displayName,
-                            target: decodeURIComponent(projectPartial.documentUri),
-                        });
-                    }
+                if (documentLink != null) {
+                    documentLinks.push(documentLink);
                 }
             }
         }

--- a/server/src/test/document_links.test.ts
+++ b/server/src/test/document_links.test.ts
@@ -1,0 +1,60 @@
+import assert from "assert";
+import { IProjectDetailsProvider } from "../projects/projectDetailsProvider.js";
+import { IView } from "../projects/views/view.js";
+import { AntlersDocument } from "../runtime/document/antlersDocument.js";
+import { makePartialDocumentLink } from "../services/antlersLinks.js";
+
+const partial = {
+    displayName: "Introduction",
+    documentUri: "file:///project/resources/views/page_builder/projects/introduction.antlers.html",
+} as IView;
+
+function makeProject() {
+    return {
+        findRelativeView(name: string) {
+            return name == "page_builder/projects/introduction" ? partial : null;
+        },
+    } as IProjectDetailsProvider;
+}
+
+function makeLink(input: string) {
+    const node = AntlersDocument.fromText(input).getAllAntlersNodes()[0];
+
+    return makePartialDocumentLink(node, makeProject());
+}
+
+suite("Document Links", () => {
+    test("it links method-style partials", () => {
+        const link = makeLink("{{ partial:page_builder/projects/introduction }}");
+
+        assert.notStrictEqual(link, null);
+        assert.strictEqual(link?.tooltip, "Partial: Introduction");
+        assert.strictEqual(link?.target, partial.documentUri);
+    });
+
+    test("it links double-quoted src partials", () => {
+        const input = '{{ partial src="page_builder/projects/introduction" }}';
+        const link = makeLink(input);
+
+        assert.deepStrictEqual(link?.range, {
+            start: { line: 0, character: 16 },
+            end: { line: 0, character: 50 },
+        });
+        assert.strictEqual(input.slice(link?.range.start.character, link?.range.end.character), "page_builder/projects/introduction");
+    });
+
+    test("it links single-quoted src partials", () => {
+        const link = makeLink("{{ partial src='page_builder/projects/introduction' }}");
+
+        assert.notStrictEqual(link, null);
+        assert.strictEqual(link?.target, partial.documentUri);
+    });
+
+    test("it does not link dynamic src parameters", () => {
+        assert.strictEqual(makeLink('{{ partial :src="page_builder/projects/introduction" }}'), null);
+    });
+
+    test("it does not link unknown partials", () => {
+        assert.strictEqual(makeLink('{{ partial src="unknown" }}'), null);
+    });
+});


### PR DESCRIPTION
## Summary
- resolve document links for `partial src=...` calls
- preserve method-style partial links
- ignore dynamic and unresolved partial sources
- cover quoted source parameters and exact link ranges

## Verification
- `npm run compile`
- 289 server tests passing

Fixes #103