### PR TITLE
Improve Antlers syntax highlighting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
                 "path": "./syntaxes/antlers.json",
                 "embeddedLanguages": {
                     "meta.embedded.block.frontmatter": "yaml",
+                    "meta.embedded.inline.alpinejs": "javascript",
                     "source.php": "php",
                     "source.js": "js"
                 }

--- a/client/src/test/syntax_grammar.test.ts
+++ b/client/src/test/syntax_grammar.test.ts
@@ -1,0 +1,280 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as oniguruma from "vscode-oniguruma";
+import * as textmate from "vscode-textmate";
+
+const htmlGrammar = {
+    scopeName: "text.html.basic",
+    patterns: [
+        { include: "#tag" }
+    ],
+    repository: {
+        tag: {
+            begin: "(</?)([A-Za-z][\\w-]*)(?=\\s|/?>)",
+            beginCaptures: {
+                1: { name: "punctuation.definition.tag.begin.html" },
+                2: { name: "entity.name.tag.html" }
+            },
+            end: "(/?>)",
+            endCaptures: {
+                1: { name: "punctuation.definition.tag.end.html" }
+            },
+            name: "meta.tag.other.html",
+            patterns: [
+                { include: "#attribute" }
+            ]
+        },
+        attribute: {
+            patterns: [
+                {
+                    begin: "([^\\s\"'<>/=]+)",
+                    beginCaptures: {
+                        1: { name: "entity.other.attribute-name.html" }
+                    },
+                    end: "(?=\\s|/?>)",
+                    name: "meta.attribute.unrecognized.html",
+                    patterns: [
+                        {
+                            begin: "=",
+                            beginCaptures: {
+                                0: { name: "punctuation.separator.key-value.html" }
+                            },
+                            end: "(?=\\s|/?>)",
+                            patterns: [
+                                {
+                                    begin: "\"",
+                                    beginCaptures: {
+                                        0: { name: "punctuation.definition.string.begin.html" }
+                                    },
+                                    end: "\"",
+                                    endCaptures: {
+                                        0: { name: "punctuation.definition.string.end.html" }
+                                    },
+                                    name: "string.quoted.double.html"
+                                },
+                                {
+                                    begin: "'",
+                                    beginCaptures: {
+                                        0: { name: "punctuation.definition.string.begin.html" }
+                                    },
+                                    end: "'",
+                                    endCaptures: {
+                                        0: { name: "punctuation.definition.string.end.html" }
+                                    },
+                                    name: "string.quoted.single.html"
+                                },
+                                {
+                                    match: "[^\\s>]+",
+                                    name: "string.unquoted.html"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+} as unknown as textmate.IRawGrammar;
+
+const javascriptGrammar = {
+    scopeName: "source.js",
+    patterns: [
+        { include: "#expression" }
+    ],
+    repository: {
+        expression: {
+            patterns: [
+                {
+                    match: "\\b(false|true|null|undefined)\\b",
+                    name: "constant.language.js"
+                },
+                {
+                    match: "!|={1,3}|\\?|:",
+                    name: "keyword.operator.js"
+                },
+                {
+                    match: "[A-Za-z_$][\\w$]*",
+                    name: "variable.other.readwrite.js"
+                }
+            ]
+        }
+    }
+} as unknown as textmate.IRawGrammar;
+
+let grammar: textmate.IGrammar;
+
+function findOccurrence(input: string, search: string, occurrence = 0): number {
+    let index = -1;
+
+    for (let i = 0; i <= occurrence; i++) {
+        index = input.indexOf(search, index + 1);
+    }
+
+    assert.notStrictEqual(index, -1, `Could not find ${search} in ${input}`);
+
+    return index;
+}
+
+function getToken(line: string, search: string, occurrence = 0, offset = 0) {
+    const index = findOccurrence(line, search, occurrence) + offset;
+    const tokens = grammar.tokenizeLine(line, textmate.INITIAL).tokens;
+    const token = tokens.find((candidate) => candidate.startIndex <= index && candidate.endIndex > index);
+
+    assert.notStrictEqual(token, undefined, `Could not find a token at ${index} in ${line}`);
+
+    return token as textmate.IToken;
+}
+
+function assertScope(line: string, search: string, scope: string, occurrence = 0, offset = 0) {
+    const token = getToken(line, search, occurrence, offset);
+
+    assert.ok(
+        token.scopes.includes(scope),
+        `Expected ${search} to include ${scope}, received ${token.scopes.join(", ")}`
+    );
+}
+
+function assertWithoutScope(line: string, search: string, scope: string, occurrence = 0, offset = 0) {
+    const token = getToken(line, search, occurrence, offset);
+
+    assert.ok(
+        !token.scopes.includes(scope),
+        `Expected ${search} not to include ${scope}, received ${token.scopes.join(", ")}`
+    );
+}
+
+function assertNoInvalidScopes(line: string) {
+    const invalidTokens = grammar.tokenizeLine(line, textmate.INITIAL).tokens.filter((token) => {
+        return token.scopes.some((scope) => scope.startsWith("invalid."));
+    });
+
+    assert.deepStrictEqual(invalidTokens, []);
+}
+
+suite("Syntax Grammar", () => {
+    suiteSetup(async () => {
+        const wasm = fs.readFileSync(path.resolve("node_modules/vscode-oniguruma/release/onig.wasm"));
+        const wasmBuffer = wasm.buffer.slice(wasm.byteOffset, wasm.byteOffset + wasm.byteLength) as ArrayBuffer;
+
+        await oniguruma.loadWASM(wasmBuffer);
+
+        const antlersGrammar = fs.readFileSync(path.resolve("client/syntaxes/antlers.json"), "utf8");
+        const registry = new textmate.Registry({
+            onigLib: Promise.resolve({
+                createOnigScanner(patterns) {
+                    return new oniguruma.OnigScanner(patterns);
+                },
+                createOnigString(input) {
+                    return new oniguruma.OnigString(input);
+                }
+            }),
+            loadGrammar: async (scopeName) => {
+                if (scopeName == "text.html.statamic") {
+                    return textmate.parseRawGrammar(antlersGrammar, "antlers.json");
+                }
+
+                if (scopeName == "text.html.basic") {
+                    return htmlGrammar;
+                }
+
+                if (scopeName == "source.js") {
+                    return javascriptGrammar;
+                }
+
+                return null;
+            }
+        });
+        const loadedGrammar = await registry.loadGrammar("text.html.statamic");
+
+        assert.notStrictEqual(loadedGrammar, null);
+        grammar = loadedGrammar as textmate.IGrammar;
+    });
+
+    test("it highlights Antlers expressions between HTML attributes", () => {
+        const line = `<a href="{{ url }}" class="tx" {{ is_current ? 'aria-current="page"' : '' }}>{{ title }}</a>`;
+
+        assertScope(line, "is_current", "variable.statamic");
+        assertScope(line, "?", "keyword.operator.logical.statamic");
+        assertScope(line, "aria-current=\"page\"", "string.quoted.single.statamic");
+        assertScope(line, "title", "variable.statamic");
+        assertNoInvalidScopes(line);
+    });
+
+    test("it preserves modifier strings inside HTML attributes", () => {
+        const line = `<iframe src="{{ url | replace('watch?v=','/embed/') }}" frameborder="0">`;
+
+        assertScope(line, "watch?v=", "string.quoted.single.statamic");
+        assertScope(line, "/embed/", "string.quoted.single.statamic");
+        assertScope(line, "frameborder", "entity.other.attribute-name.html");
+        assertNoInvalidScopes(line);
+    });
+
+    test("it preserves HTML boundaries around conditional attributes", () => {
+        const line = `<a class="nav-link{{ if is_current }} active{{ /if }}"{{ if is_current }} aria-current="page"{{ /if }} href="{{ url }}">`;
+
+        assertScope(line, "{{ if", "keyword.control.statamic", 1, 3);
+        assertScope(line, "{{ /if", "keyword.control.statamic", 1, 3);
+        assertScope(line, "aria-current", "entity.other.attribute-name.html");
+        assertScope(line, "href", "entity.other.attribute-name.html");
+        assertNoInvalidScopes(line);
+    });
+
+    test("it preserves HTML boundaries after Antlers in style attributes", () => {
+        const line = `<li style="background-image: url('{{ glide :src="background_image" w="1920" format="webp" }}');" class="active">`;
+
+        assertScope(line, "background_image", "variable.statamic");
+        assertScope(line, "class", "entity.other.attribute-name.html");
+        assertScope(line, "active", "string.quoted.double.html");
+        assertNoInvalidScopes(line);
+    });
+
+    test("it highlights dynamic opening tags and their attributes", () => {
+        const line = `<{{ card_html_tag }} class="card">`;
+
+        assertScope(line, "<", "punctuation.definition.tag.begin.html");
+        assertScope(line, "card_html_tag", "meta.tag.other.dynamic.html");
+        assertScope(line, "card_html_tag", "variable.statamic");
+        assertScope(line, "class", "entity.other.attribute-name.html");
+        assertScope(line, "\"card\"", "string.quoted.double.html", 0, 1);
+        assertScope(line, ">", "punctuation.definition.tag.end.html");
+    });
+
+    test("it highlights dynamic closing tags", () => {
+        const line = `</{{ card_html_tag }}>`;
+
+        assertScope(line, "</", "punctuation.definition.tag.begin.html");
+        assertScope(line, "card_html_tag", "variable.statamic");
+        assertScope(line, ">", "punctuation.definition.tag.end.html");
+    });
+
+    test("it embeds JavaScript in Alpine attributes", () => {
+        const line = `<button x-data="{ open: false }" @click="open = !open" :class="{ 'is-open': open }" x-show="open">`;
+
+        assertScope(line, "x-data", "meta.attribute.alpine");
+        assertScope(line, "false", "constant.language.js");
+        assertScope(line, "@click", "meta.attribute.alpine");
+        assertScope(line, "!open", "keyword.operator.js");
+        assertScope(line, ":class", "meta.attribute.alpine");
+        assertScope(line, "is-open", "meta.embedded.inline.alpinejs");
+        assertScope(line, "x-show", "meta.attribute.alpine");
+    });
+
+    test("it supports Alpine arguments and modifiers", () => {
+        const line = `<div x-on:click.prevent="open = true" x-bind:class="classes"></div>`;
+
+        assertScope(line, "x-on:click.prevent", "meta.attribute.alpine");
+        assertScope(line, "true", "constant.language.js");
+        assertScope(line, "x-bind:class", "meta.attribute.alpine");
+        assertScope(line, "classes", "meta.embedded.inline.alpinejs");
+    });
+
+    test("it limits Alpine highlighting to HTML attributes", () => {
+        const html = `<div class="x-data"></div>`;
+        const antlers = `{{ partial x-data="not_alpine" }}`;
+
+        assertWithoutScope(html, "class", "meta.attribute.alpine");
+        assertWithoutScope(antlers, "x-data", "meta.attribute.alpine");
+        assertScope(antlers, "x-data", "entity.other.attribute-name");
+    });
+});

--- a/client/syntaxes/antlers.json
+++ b/client/syntaxes/antlers.json
@@ -3,6 +3,23 @@
     "fileTypes": ["antlers.html", "antlers.php", "antlers.xml", "html", "htm", "xhtml"],
 	"scopeName": "text.html.statamic",
 	"injections": {
+		"L:(text.html.statamic meta.tag - (meta.embedded.block.statamic | meta.embedded.line.statamic | comment.block.statamic | comment.block.html))": {
+			"patterns": [
+				{
+					"include": "#alpine-attribute"
+				}
+			]
+		},
+		"L:text.html.statamic": {
+			"patterns": [
+				{
+					"include": "#statamic-comments"
+				},
+				{
+					"include": "#antlers-tags"
+				}
+			]
+		},
 		"text.html.statamic - (meta.embedded | meta.tag), L:((text.html.statamic meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))": {
 			"patterns": [
 				{
@@ -15,16 +32,6 @@
 				{
 					"comment": "This is set to use XHTML standards, but you can change that by changing .strict to .basic for HTML standards",
 					"include": "text.html.basic"
-				}
-			]
-		},
-		"text.html.statamic": {
-			"patterns": [
-				{
-					"include": "#statamic-comments"
-				},
-				{
-					"include": "#antlers-tags"
 				}
 			]
 		}
@@ -40,10 +47,123 @@
 			"include": "#frontMatter"
 		},
 		{
+			"include": "#dynamic-html-tag"
+		},
+		{
 			"include": "#antlers-tags"
 		}
 	],
 	"repository": {
+		"dynamic-html-tag": {
+			"begin": "(</?)(?={{)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html"
+				}
+			},
+			"end": "(/?>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html"
+				}
+			},
+			"name": "meta.tag.other.dynamic.html",
+			"patterns": [
+				{
+					"include": "#antlers-tags"
+				},
+				{
+					"include": "text.html.basic#attribute"
+				}
+			]
+		},
+		"alpine-attribute": {
+			"name": "meta.attribute.alpine",
+			"begin": "(?:\\b(x-)|(:|@|#))([a-zA-Z0-9\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z0-9\\-_]+))*\\s*(=)",
+			"end": "(?<=['\"`])|(?=[\\s<>])",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.html"
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html"
+				},
+				"3": {
+					"name": "entity.other.attribute-name.html"
+				},
+				"4": {
+					"name": "entity.other.attribute-name.html"
+				},
+				"5": {
+					"name": "entity.other.attribute-name.html"
+				},
+				"6": {
+					"name": "punctuation.separator.key-value.html"
+				}
+			},
+			"patterns": [
+				{
+					"contentName": "meta.embedded.inline.alpinejs",
+					"begin": "`",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.html"
+						}
+					},
+					"end": "`",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.html"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.js#expression"
+						}
+					]
+				},
+				{
+					"contentName": "meta.embedded.inline.alpinejs",
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.html"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.html"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.js#expression"
+						}
+					]
+				},
+				{
+					"contentName": "meta.embedded.inline.alpinejs",
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.html"
+						}
+					},
+					"end": "'",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.html"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.js#expression"
+						}
+					]
+				}
+			]
+		},
 		"php-tag": {
 			"patterns": [
 				{
@@ -263,7 +383,7 @@
 					"name": "keyword.operator.assignment.statamic"
 				},
 				{
-                    "match": "(?<!-)\\b(?i)(!|\\?\\?|\\?=|\\?|&&|&|\\|\\|)|\\b(and|or|xor)\\b",
+                    "match": "(?<!-)(!|\\?\\?|\\?=|\\?|&&|&|\\|\\|)|(?i:\\b(and|or|xor)\\b)",
 					"name": "keyword.operator.logical.statamic"
 				},
 				{
@@ -334,7 +454,7 @@
 			]
 		},
 		"antlers-tag-parameter-variable": {
-			"match": "(:?([\\S:]+?)(=)('|\")([^\\4]*?)(\\4))",
+			"match": "(?<!\\S)(:?([\\S:]+?)(=)('|\")([^\\4]*?)(\\4))",
 			"captures": {
 				"1": {
 					"patterns": [

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,7 +7,8 @@
 		],
 		"outDir": "out",
 		"rootDir": "src",
-		"sourceMap": true
+		"sourceMap": true,
+		"skipLibCheck": true
 	},
 	"include": [
 		"src"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
                 "esbuild": "^0.14.54",
                 "eslint": "^8.38.0",
                 "mocha": "^10.2.0",
-                "typescript": "^4.9.5"
+                "typescript": "^4.9.5",
+                "vscode-oniguruma": "^2.0.1",
+                "vscode-textmate": "^9.3.2"
             },
             "engines": {
                 "vscode": "^1.43.0"
@@ -2064,6 +2066,20 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+            "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vscode-textmate": {
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+            "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
                 "path": "./client/syntaxes/antlers.json",
                 "embeddedLanguages": {
                     "meta.embedded.block.frontmatter": "yaml",
+                    "meta.embedded.inline.alpinejs": "javascript",
                     "source.php": "php",
                     "source.js": "js"
                 }
@@ -201,7 +202,8 @@
         "build:webview": "cd docsui && npm run build",
         "postinstall": "cd client && npm install && cd ../server && npm install && cd ../docsui && npm install && cd ..",
         "bundle:everything": "npm run bundle:format_cli && npm run bundle:antlersls && npm run bundle:prettier",
-        "test:server": "npm run compile && mocha ./server/out/test/*.js -- -u tdd"
+        "test:server": "npm run compile && mocha ./server/out/test/*.js -- -u tdd",
+        "test:grammar": "npm run compile && mocha ./client/out/test/syntax_grammar.test.js -- -u tdd"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.3",
@@ -209,7 +211,9 @@
         "esbuild": "^0.14.54",
         "eslint": "^8.38.0",
         "mocha": "^10.2.0",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
     },
     "dependencies": {
         "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary
- prioritize Antlers scopes inside and between HTML attributes
- keep modifier strings containing equals signs inside string scopes
- preserve HTML attribute boundaries around conditional Antlers regions
- highlight Antlers variables used as opening and closing HTML tag names
- embed JavaScript scopes in Alpine `x-`, `@`, and `:` attributes
- add TextMate scope regressions for the reported templates

## Verification
- `npm run compile`
- 9 grammar tests passing
- 284 server tests passing
- smoke-tested against VS Code's current official HTML grammar

Fixes #93
Fixes #91
Fixes #105