### PR TITLE
Fix nested switch formatting

### DIFF
--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -5,8 +5,8 @@ export class NodeBuffer {
     private baseIndent: number;
     private buffer = '';
     private closeString = '';
-    private relativeIndentSize = 0;
     private indentSeed = 0;
+    private contentIndent = 0;
 
     constructor(node: AntlersNode, indent: number, prepend: string | null) {
         this.baseIndent = indent;
@@ -31,6 +31,8 @@ export class NodeBuffer {
         if (prepend != null && prepend.trim().length > 0) {
             this.buffer += prepend + ' ';
         }
+
+        this.contentIndent = this.buffer.length + (node.isInterpolationNode ? 1 : 0);
     }
 
     setIndentSeed(indent: number) {
@@ -54,8 +56,12 @@ export class NodeBuffer {
     }
 
     appendT(text: string) {
-        if (this.buffer.endsWith(' ')) {
-            this.buffer = this.buffer.trimEnd();
+        const currentLine = this.buffer.substring(this.buffer.lastIndexOf("\n") + 1);
+
+        if (currentLine.trim().length == 0) {
+            text = text.trimStart();
+        } else if (this.buffer.endsWith(' ')) {
+            this.buffer = this.buffer.replace(/[ \t]+$/, '');
         }
 
         this.buffer += text;
@@ -64,8 +70,12 @@ export class NodeBuffer {
     }
 
     appendTS(text: string, preserveSpace = false) {
-        if (this.buffer.endsWith(' ')) {
-            this.buffer = this.buffer.trimEnd();
+        const currentLine = this.buffer.substring(this.buffer.lastIndexOf("\n") + 1);
+
+        if (currentLine.trim().length == 0) {
+            text = text.trimStart();
+        } else if (this.buffer.endsWith(' ')) {
+            this.buffer = this.buffer.replace(/[ \t]+$/, '');
         }
 
         if (this.buffer.endsWith('{') && !preserveSpace) {
@@ -114,10 +124,6 @@ export class NodeBuffer {
 
         if (repeatCount == 0) { repeatCount = 1; } else { repeatCount += 2; }
 
-        if (this.relativeIndentSize > 0) {
-            repeatCount += this.relativeIndentSize;
-        }
-
         this.buffer += ' '.repeat(repeatCount);
 
         return this;
@@ -129,6 +135,20 @@ export class NodeBuffer {
         this.buffer += ' '.repeat(number);
 
         return this;
+    }
+
+    newlineAt(indent: number) {
+        this.buffer = this.buffer.trimEnd() + "\n";
+
+        if (indent > 0) {
+            this.buffer += ' '.repeat(indent);
+        }
+
+        return this;
+    }
+
+    getContentIndent() {
+        return this.contentIndent;
     }
 
     paramS(param: ParameterNode) {
@@ -147,32 +167,6 @@ export class NodeBuffer {
 
     replace(find: string, replace: string) {
         this.buffer = replaceAllInString(this.buffer, find, replace);
-
-        return this;
-    }
-
-    relativeIndent(relativeTo: string) {
-        const bufferLines = this.buffer.split("\n");
-
-        if (bufferLines.length == 0) {
-            return this;
-        }
-
-        let lastLine = bufferLines[bufferLines.length - 1].trimEnd();
-
-        if (lastLine.endsWith('(')) {
-            lastLine = lastLine.slice(0, -1);
-        }
-
-        if (lastLine.endsWith(relativeTo) == false) {
-            return this;
-        }
-
-        this.relativeIndentSize = lastLine.lastIndexOf(relativeTo);
-
-        //  this.relativeIndentSize += Math.ceil(relativeTo.length / 2);
-
-        // this.relativeIndentSize += 4;
 
         return this;
     }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -22,6 +22,35 @@ export class NodePrinter {
                 nodeBuffer.setIndentSeed(seedIndent);
             }
 
+            const groupsContainingSwitch = new Set<LogicGroupBegin>(),
+                groupScanStack: LogicGroupBegin[] = [];
+
+            for (let i = 0; i < lexerNodes.length; i++) {
+                const scanNode = lexerNodes[i];
+
+                if (scanNode instanceof LogicGroupBegin) {
+                    groupScanStack.push(scanNode);
+                } else if (scanNode instanceof LogicGroupEnd) {
+                    groupScanStack.pop();
+                } else if (scanNode instanceof VariableNode && scanNode.convertedToOperator && scanNode.name == 'switch') {
+                    groupScanStack.forEach((group) => groupsContainingSwitch.add(group));
+                }
+            }
+
+            type LayoutGroup = {
+                type: 'inline' | 'switch' | 'wrapped'
+            };
+
+            const layoutGroups: LayoutGroup[] = [];
+            let layoutDepth = 0;
+            const indentForDepth = (depth: number) => {
+                if (depth <= 0) {
+                    return 0;
+                }
+
+                return nodeBuffer.getContentIndent() + ((depth - 1) * options.tabSize);
+            };
+
             let lastPrintedNode: AbstractNode | null = null;
 
 
@@ -39,7 +68,9 @@ export class NodePrinter {
                 if (node instanceof LogicGroupEnd) {
                     if (node.next instanceof LogicGroupEnd == false && node.next != null) {
                         if (!LanguageParser.isOperatorType(node.next) || !LanguageParser.isAssignmentOperator(node.next)) {
-                            if (node.next instanceof StatementSeparatorNode == false && node.next instanceof InlineBranchSeparator == false) {
+                            if (node.next instanceof StatementSeparatorNode == false
+                                && node.next instanceof InlineBranchSeparator == false
+                                && node.next instanceof ArgSeparator == false) {
                                 if (!node.isSwitchGroupMember && !LanguageParser.isOperatorType(node.next)) {
                                     insertNlAfter = true;
 
@@ -85,16 +116,20 @@ export class NodePrinter {
                                     break;
                                 }
 
-                                // Keep <switch/list>( together, and start a new line for the conditions.
-
                                 nodeBuffer.append('(');
-                                if (node.name != 'list') {
-                                    nodeBuffer
-                                        .relativeIndent(node.name)
-                                        .newLine().indent();
+                                const groupType = node.name == 'switch'
+                                    ? 'switch'
+                                    : (groupsContainingSwitch.has(next) ? 'wrapped' : 'inline');
+
+                                layoutGroups.push({ type: groupType });
+
+                                if (groupType != 'inline') {
+                                    layoutDepth += 1;
+                                    nodeBuffer.newlineAt(indentForDepth(layoutDepth));
                                 }
+
                                 i += 1;
-                                lastPrintedNode = lexerNodes[i + 1];
+                                lastPrintedNode = next;
                                 continue;
                             } else {
                                 break;
@@ -151,8 +186,9 @@ export class NodePrinter {
                         // Keep <switch/list>( together, and start a new line for the conditions.
 
                         nodeBuffer.append('(');
+                        layoutGroups.push({ type: 'inline' });
                         i += 1;
-                        lastPrintedNode = lexerNodes[i + 1];
+                        lastPrintedNode = next;
                         continue;
                     } else {
                         break;
@@ -226,7 +262,22 @@ export class NodePrinter {
                     nodeBuffer.append(node.value.trim());
                 } else if (node instanceof LogicGroupBegin) {
                     nodeBuffer.append('(');
+                    const groupType = groupsContainingSwitch.has(node) ? 'wrapped' : 'inline';
+
+                    layoutGroups.push({ type: groupType });
+
+                    if (groupType == 'wrapped') {
+                        layoutDepth += 1;
+                        nodeBuffer.newlineAt(indentForDepth(layoutDepth));
+                    }
                 } else if (node instanceof LogicGroupEnd) {
+                    const layoutGroup = layoutGroups.pop();
+
+                    if (layoutGroup != null && layoutGroup.type != 'inline') {
+                        layoutDepth = Math.max(0, layoutDepth - 1);
+                        nodeBuffer.newlineAt(indentForDepth(layoutDepth));
+                    }
+
                     nodeBuffer.append(')');
                 } else if (node instanceof StringValueNode) {
                     if (doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node)) {
@@ -239,9 +290,10 @@ export class NodePrinter {
                         nodeBuffer.appendOS(node.sourceTerminator + node.value + node.sourceTerminator);
                     }
                 } else if (node instanceof ArgSeparator) {
-                    if (node.isSwitchGroupMember) {
-                        nodeBuffer.append(',')
-                            .newlineIndent();
+                    const layoutGroup = layoutGroups[layoutGroups.length - 1];
+
+                    if (layoutGroup != null && layoutGroup.type != 'inline') {
+                        nodeBuffer.append(',').newlineAt(indentForDepth(layoutDepth));
                     } else {
                         nodeBuffer.append(', ');
                     }

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -1,7 +1,7 @@
 import { AsyncHTMLFormatter, AsyncPHPFormatter, HTMLFormatter, PHPFormatter, YAMLFormatter } from '../../formatting/formatters.js';
 import { replaceAllInString } from '../../utils/strings.js';
 import { ConditionPairAnalyzer } from '../analyzers/conditionPairAnalyzer.js';
-import { AbstractNode, AntlersNode, ConditionNode, EscapedContentNode, ExecutionBranch, FragmentPosition, LiteralNode, StructuralFragment } from '../nodes/abstractNode.js';
+import { AbstractNode, AntlersNode, ConditionNode, EscapedContentNode, ExecutionBranch, FragmentPosition, LiteralNode, StructuralFragment, VariableNode } from '../nodes/abstractNode.js';
 import { StringUtilities } from '../utilities/stringUtilities.js';
 import { AntlersDocument } from './antlersDocument.js';
 import { AsyncInlineFormatter, InlineFormatter } from './inlineFormatter.js';
@@ -74,6 +74,7 @@ export class Transformer {
     private inlineIfs: Map<string, ConditionNode> = new Map();
     private createExraStructuralPairs = false;
     private spanNodes: Map<string, AntlersNode> = new Map();
+    private multilineSpanSlugs: Set<string> = new Set();
     private inlineNodes: Map<string, AntlersNode> = new Map();
     private virtualBlocks: VirtualBlockStructure[] = [];
     private inlineComments: Map<string, AntlersNode> = new Map();
@@ -114,6 +115,12 @@ export class Transformer {
         this.asyncInlineFormatter = asyncInlineFormatter;
 
         return this;
+    }
+
+    private hasSwitchOperator(node: AntlersNode): boolean {
+        return node.getTrueNode().getTrueRuntimeNodes().some((runtimeNode) => runtimeNode instanceof VariableNode
+            && runtimeNode.convertedToOperator
+            && runtimeNode.name == 'switch');
     }
 
     produceExtraStructuralPairs(doCreate: boolean) {
@@ -303,7 +310,7 @@ export class Transformer {
         return value;
     }
 
-    private async printNodeAsync(node: AntlersNode, targetIndent: number | null = null): Promise<string> {
+    private async printNodeAsync(node: AntlersNode, targetIndent: number | null = null, alignContinuation = false): Promise<string> {
         const printNode = node.getTrueNode();
 
         if ((printNode.rawStart == '{{?' || printNode.rawStart == '{{$') && this.asyncPhpFormatter != null) {
@@ -340,10 +347,10 @@ export class Transformer {
 
         let result = NodePrinter.prettyPrintNode(printNode, doc, 0, this.options, prepend, null);
 
-        const forceBreakOperatorNames = ['switch', 'list'];
-
         if (targetIndent != null && result.includes("\n")) {
-            if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
+            if (alignContinuation || this.hasSwitchOperator(printNode)) {
+                result = IndentLevel.shiftIndent(result, targetIndent, true, this.options.tabSize, false);
+            } else if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
                 result = IndentLevel.shiftIndent(result, targetIndent + this.options.tabSize, true);
             } else {
                 result = IndentLevel.shiftIndent(result, targetIndent - (this.options.tabSize * 2), true);
@@ -353,7 +360,7 @@ export class Transformer {
         return result;
     }
 
-    private printNode(node: AntlersNode, targetIndent: number | null = null) {
+    private printNode(node: AntlersNode, targetIndent: number | null = null, alignContinuation = false) {
         const printNode = node.getTrueNode();
 
         if ((printNode.rawStart == '{{?' || printNode.rawStart == '{{$') && this.phpFormatter != null) {
@@ -390,10 +397,10 @@ export class Transformer {
 
         let result = NodePrinter.prettyPrintNode(printNode, doc, 0, this.options, prepend, null);
 
-        const forceBreakOperatorNames = ['switch', 'list'];
-
         if (targetIndent != null && result.includes("\n")) {
-            if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
+            if (alignContinuation || this.hasSwitchOperator(printNode)) {
+                result = IndentLevel.shiftIndent(result, targetIndent, true, this.options.tabSize, false);
+            } else if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
                 result = IndentLevel.shiftIndent(result, targetIndent + this.options.tabSize, true);
             } else {
                 result = IndentLevel.shiftIndent(result, targetIndent - (this.options.tabSize * 2), true);
@@ -746,6 +753,12 @@ export class Transformer {
             if (node.isInlineAntlers) {
                 this.spanNodes.set(slug, node);
 
+                if (this.hasSwitchOperator(node)) {
+                    this.multilineSpanSlugs.add(slug);
+
+                    return slug + "\n";
+                }
+
                 return slug;
             } else {
                 this.inlineNodes.set(slug, node);
@@ -936,14 +949,15 @@ export class Transformer {
         }
 
         for (const [slug, node] of this.spanNodes) {
-            let level = 0;
-
-            if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
-                level = this.indentLevel(slug, true);
-            }
-
-            const printed = await this.printNodeAsync(node, level),
+            const alignContinuation = this.multilineSpanSlugs.has(slug),
+                level = alignContinuation ? this.indentLevel(slug, true) : 0,
+                printed = await this.printNodeAsync(node, level, alignContinuation),
                 slugNs = this.selfClosingNs(slug);
+
+            if (this.multilineSpanSlugs.has(slug)) {
+                value = value.replace(slug + "\r\n", printed);
+                value = value.replace(slug + "\n", printed);
+            }
 
             value = value.replace(slug, printed);
             value = value.replace(slugNs, printed);
@@ -1013,14 +1027,15 @@ export class Transformer {
         });
 
         this.spanNodes.forEach((node: AntlersNode, slug: string) => {
-            let level = 0;
-
-            if (node.isVirtual && (node.name?.name == 'switch' || node.name?.name == 'list')) {
-                level = this.indentLevel(slug, true);
-            }
-
-            const printed = this.printNode(node, level),
+            const alignContinuation = this.multilineSpanSlugs.has(slug),
+                level = alignContinuation ? this.indentLevel(slug, true) : 0,
+                printed = this.printNode(node, level, alignContinuation),
                 slugNs = this.selfClosingNs(slug);
+
+            if (this.multilineSpanSlugs.has(slug)) {
+                value = value.replace(slug + "\r\n", printed);
+                value = value.replace(slug + "\n", printed);
+            }
 
             value = value.replace(slug, printed);
             value = value.replace(slugNs, printed);
@@ -1150,7 +1165,15 @@ export class Transformer {
                 let indent = thisLine.length - trimmed.length;
 
                 if (includeIndex) {
-                    indent += thisLine.indexOf(value);
+                    const valueIndex = thisLine.indexOf(value);
+
+                    const inlineAlignmentLimit = Math.max(this.options.tabSize * 3, 12);
+
+                    if (valueIndex - indent <= inlineAlignmentLimit) {
+                        indent = valueIndex;
+                    } else {
+                        indent += this.options.tabSize;
+                    }
                 }
 
                 return indent;

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -201,7 +201,7 @@ suite('Formatter Operators', () => {
         assert.strictEqual(formatAntlers('{{ left where       right }}'), '{{ left where right }}');
     });
 
-    test('it preserves space on switch and inlines expanded groups', () => {
+    test('it formats switches in inline attributes', () => {
         const input = `{{#
     @name h1
     @desc The typography h1 partial to render an h1 with \`class\`, \`as\`, \`color\` and \`content\` attributes.
@@ -234,8 +234,9 @@ suite('Formatter Operators', () => {
 
 <!-- /typography/_h1.antlers.html -->
 <{{ as or 'h1' }} class="{{ switch(
-                              (format == 'eyebrow') => '',
-                              () => 'text-2xl md:text-4xl font-bold leading-tight') }}
+       (format == 'eyebrow') => '',
+       () => 'text-2xl md:text-4xl font-bold leading-tight'
+    ) }}
         {{ color or 'text-neutral' }} {{ class }}">
     {{ content | nl2br }}
 </{{ as or 'h1' }}>
@@ -252,10 +253,11 @@ suite('Formatter Operators', () => {
 (size == 'xl') => '90vw'
 )}" }}`;
         const expected = `{{ test variable="{ switch(
-   (size == 'sm') => '(min-width: 768px) 35vw, 90vw',
-   (size == 'md') => '(min-width: 768px) 55vw, 90vw',
-   (size == 'lg') => '(min-width: 768px) 75vw, 90vw',
-   (size == 'xl') => '90vw')}" }}`;
+  (size == 'sm') => '(min-width: 768px) 35vw, 90vw',
+  (size == 'md') => '(min-width: 768px) 55vw, 90vw',
+  (size == 'lg') => '(min-width: 768px) 75vw, 90vw',
+  (size == 'xl') => '90vw'
+)}" }}`;
 
         assert.strictEqual(formatAntlers(input), expected);
     });
@@ -337,9 +339,9 @@ suite('Formatter Operators', () => {
                             {{ five }}
                                 {{ six }}
                                     {{ parity = switch(
-                                             ((index | mod:2) == 0) => 'even',
-                                             ((index | mod:2) == 1) => 'odd',
-                                         ) }}
+                                       ((index | mod:2) == 0) => 'even',
+                                       ((index | mod:2) == 1) => 'odd',
+                                    ) }}
                                 {{ /six }}
                             {{ /five }}
                         {{ /four }}

--- a/server/src/test/formatter_prettier_switch.test.ts
+++ b/server/src/test/formatter_prettier_switch.test.ts
@@ -1,0 +1,137 @@
+import assert from 'assert';
+import * as prettier from 'prettier';
+import plugin from '../formatting/prettier/plugin.js';
+
+async function format(template: string, tabWidth = 4): Promise<string> {
+    return (await prettier.format(template, {
+        parser: 'antlers',
+        plugins: [plugin],
+        tabWidth: tabWidth
+    })).trim();
+}
+
+async function assertStable(template: string, expected: string, tabWidth = 4) {
+    const formatted = await format(template, tabWidth);
+
+    assert.strictEqual(formatted, expected);
+    assert.strictEqual(await format(formatted, tabWidth), expected);
+}
+
+suite('Prettier Switch Formatting', () => {
+    test('it formats nested switch modifier arguments', async () => {
+        const input = `<div>
+    <div>
+        <div
+            class="{{ '' | tw_merge(
+                'flex-initial flex flex-col items-start justify-center',
+                switch
+                (
+                    (content_width === '75') => 'md:basis-3/4',
+                    (content_width === '25') => 'md:basis-full max-w-5xl items-center',
+                ),
+                switch(
+                    (background_color === 'white' || background_color === 'gray') => 'text-black',
+                    (background_color === 'charcoal') => 'text-white antialiased',
+                ),
+                switch(
+                    (padding === 'left' && image_position === 'right') => 'content:ml-breakout pl-5',
+                    (padding === 'right' && image_position === 'left') => 'content:mr-breakout pr-5',
+                ),
+            ) }}"
+        ></div>
+    </div>
+</div>`;
+        const expected = `<div>
+    <div>
+        <div
+            class="{{ '' | tw_merge(
+                      'flex-initial flex flex-col items-start justify-center',
+                      switch(
+                          (content_width === '75') => 'md:basis-3/4',
+                          (content_width === '25') => 'md:basis-full max-w-5xl items-center',
+                      ),
+                      switch(
+                          (background_color === 'white' || background_color === 'gray') => 'text-black',
+                          (background_color === 'charcoal') => 'text-white antialiased',
+                      ),
+                      switch(
+                          (padding === 'left' && image_position === 'right') => 'content:ml-breakout pl-5',
+                          (padding === 'right' && image_position === 'left') => 'content:mr-breakout pr-5',
+                      ),
+                   ) }}"
+        ></div>
+    </div>
+</div>`;
+
+        await assertStable(input, expected);
+    });
+
+    test('it keeps long attribute switches structurally indented', async () => {
+        const input = `<html>
+    <body>
+        <main
+            data-transition-namespace="{{ switch(
+    (current_template == 'projekte/index') => 'projectIndex',
+    () => 'default') }}">
+        </main>
+    </body>
+</html>`;
+        const expected = `<html>
+    <body>
+        <main
+            data-transition-namespace="{{ switch(
+                   (current_template == 'projekte/index') => 'projectIndex',
+                   () => 'default'
+                ) }}"
+        ></main>
+    </body>
+</html>`;
+
+        await assertStable(input, expected);
+    });
+
+    test('it respects two-space HTML and expression nesting', async () => {
+        const input = `<section><div><span data-value="{{ '' | tw_merge('base', switch((a == b) => foo(a, b), () => 'no')) }}"></span></div></section>`;
+        const expected = `<section>
+  <div>
+    <span
+      data-value="{{ '' | tw_merge(
+                     'base',
+                     switch(
+                       (a == b) => foo(a, b),
+                       () => 'no'
+                     )
+                  ) }}"
+    ></span>
+  </div>
+</section>`;
+
+        await assertStable(input, expected, 2);
+    });
+
+    test('it leaves inner function arguments inline', async () => {
+        const input = `{{ value = switch((enabled) => choose(first, second), () => fallback(third, fourth)) }}`;
+        const expected = `{{ value = switch(
+   (enabled) => choose(first, second),
+   () => fallback(third, fourth)
+) }}`;
+
+        await assertStable(input, expected);
+    });
+
+    test('it wraps ancestor argument groups around nested switches', async () => {
+        const input = `{{ result = choose('before', wrapper(switch((a) => foo(a, b), () => bar(c, d))), 'after') }}`;
+        const expected = `{{ result = choose(
+   'before',
+   wrapper(
+       switch(
+           (a) => foo(a, b),
+           () => bar(c, d)
+       )
+   ),
+   'after'
+) }}`;
+
+        await assertStable(input, expected);
+    });
+});


### PR DESCRIPTION
## Summary

- format switch cases with structural indentation at any nesting depth
- wrap enclosing argument groups without moving inner function commas
- stabilize multiline switch attributes in one formatting pass
- prevent long attribute names from causing runaway or negative indentation

## Tests

- npm run compile
- full source-backed server suite: 289 passing

Fixes #81