### PR TITLE
Improve core language support

### DIFF
--- a/client/src/test/syntax_grammar.test.ts
+++ b/client/src/test/syntax_grammar.test.ts
@@ -248,6 +248,16 @@ suite("Syntax Grammar", () => {
         assertScope(line, ">", "punctuation.definition.tag.end.html");
     });
 
+    test("it highlights Antlers component tags and attributes", () => {
+        ["s-", "s:", "statamic-", "statamic:"].forEach((prefix) => {
+            const line = `<${prefix}collection from="articles"></${prefix}collection>`;
+
+            assertScope(line, "collection", "entity.name.tag.statamic");
+            assertScope(line, "from", "entity.other.attribute-name.html");
+            assertNoInvalidScopes(line);
+        });
+    });
+
     test("it embeds JavaScript in Alpine attributes", () => {
         const line = `<button x-data="{ open: false }" @click="open = !open" :class="{ 'is-open': open }" x-show="open">`;
 

--- a/client/syntaxes/antlers.json
+++ b/client/syntaxes/antlers.json
@@ -547,7 +547,7 @@
 		"core-tag-names": {
 			"patterns": [
 				{
-					"match": "(?i)\\b(taxonomy|cookie|user_groups|user_roles|get_site|collection|asset|nocache|vite|mount_url|form|assets|cache|can|dd|ddd|dump|get_content|get_error|get_errors|get_files|glide|in|increment|installed|is|iterate|foreach|link|locales|markdown|member|mix|nav|not_found|404|obfuscate|parent|partial|path|query|range|loop|redirect|relate|rotate|route|scope|section|session|set|structure|svg|theme|trans|trans_choice|user|users|widont|yields|yield|slot|once|noparse|view|stack|push)\\b",
+					"match": "(?i)\\b(taxonomy|cookie|user_groups|user_roles|get_site|collection|asset|nocache|vite|mount_url|form|assets|cache|can|children|dictionary|dd|ddd|dump|get_content|get_error|get_errors|get_files|glide|in|increment|installed|is|iterate|foreach|link|locales|markdown|member|mix|nav|not_found|404|oauth|obfuscate|parent|partial|path|protect|query|range|loop|redirect|relate|rotate|route|scope|search|section|session|set|structure|svg|theme|trans|trans_choice|user|users|widont|yields|yield|slot|once|noparse|view|stack|push)\\b",
 					"name": "entity.name.tag.statamic"
 				}
 			]

--- a/client/syntaxes/antlers.json
+++ b/client/syntaxes/antlers.json
@@ -21,6 +21,9 @@
 		"text.html.statamic": {
 			"patterns": [
 				{
+					"include": "#antlers-directives"
+				},
+				{
 					"include": "#antlers-components"
 				},
 				{
@@ -36,6 +39,9 @@
         {
             "include": "#php-tag"
         },
+		{
+			"include": "#antlers-directives"
+		},
 		{
 			"include": "#antlers-components"
 		},
@@ -140,6 +146,49 @@
 			"begin": "{{#",
 			"end": "#}}",
 			"name": "comment.block.statamic"
+		},
+		"antlers-directives": {
+			"patterns": [
+				{
+					"begin": "(?<!@)(@)(props|aware|cascade)(\\s*)(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.directive.statamic"
+						},
+						"2": {
+							"name": "support.function.directive.statamic"
+						},
+						"4": {
+							"name": "punctuation.section.group.begin.statamic"
+						}
+					},
+					"contentName": "source.php",
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.group.end.statamic"
+						}
+					},
+					"name": "meta.directive.statamic",
+					"patterns": [
+						{
+							"include": "source.php"
+						}
+					]
+				},
+				{
+					"match": "(?<!@)(@)(cascade)\\b(?!\\s*\\()",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.directive.statamic"
+						},
+						"2": {
+							"name": "support.function.directive.statamic"
+						}
+					},
+					"name": "meta.directive.statamic"
+				}
+			]
 		},
 		"antlers-components": {
 			"begin": "(<\\/?)(?:(s|statamic)([-:]))([a-zA-Z_][\\w:-]*)",

--- a/client/syntaxes/antlers.json
+++ b/client/syntaxes/antlers.json
@@ -21,6 +21,9 @@
 		"text.html.statamic": {
 			"patterns": [
 				{
+					"include": "#antlers-components"
+				},
+				{
 					"include": "#statamic-comments"
 				},
 				{
@@ -33,6 +36,9 @@
         {
             "include": "#php-tag"
         },
+		{
+			"include": "#antlers-components"
+		},
 		{
 			"include": "#statamic-comments"
 		},
@@ -134,6 +140,35 @@
 			"begin": "{{#",
 			"end": "#}}",
 			"name": "comment.block.statamic"
+		},
+		"antlers-components": {
+			"begin": "(<\\/?)(?:(s|statamic)([-:]))([a-zA-Z_][\\w:-]*)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.html"
+				},
+				"2": {
+					"name": "support.class.component.statamic"
+				},
+				"3": {
+					"name": "punctuation.separator.component.statamic"
+				},
+				"4": {
+					"name": "entity.name.tag.statamic"
+				}
+			},
+			"end": "(/?>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.end.html"
+				}
+			},
+			"name": "meta.tag.statamic.component",
+			"patterns": [
+				{
+					"include": "text.html.basic#tag-stuff"
+				}
+			]
 		},
 		"antlers-tags": {
 			"begin": "(?<!@){{(?!\\$)(\\s?)",

--- a/client/syntaxes/antlers.json
+++ b/client/syntaxes/antlers.json
@@ -335,7 +335,7 @@
 			"name": "meta.tag.statamic.component",
 			"patterns": [
 				{
-					"include": "text.html.basic#tag-stuff"
+					"include": "text.html.basic#attribute"
 				}
 			]
 		},

--- a/server/src/antlers/tags/core/additionalTagMethods.ts
+++ b/server/src/antlers/tags/core/additionalTagMethods.ts
@@ -1,0 +1,256 @@
+import { makeTagDoc } from '../../../documentation/utils.js';
+import { AntlersNode } from '../../../runtime/nodes/abstractNode.js';
+import { ISuggestionRequest } from '../../../suggestions/suggestionRequest.js';
+import { Scope } from '../../scope/scope.js';
+import { exclusiveResultList, IAntlersParameter, IAntlersTag } from '../../tagManager.js';
+import { makeFieldsVariables } from '../../variables/forms/fieldsVariables.js';
+import { makeGlideVariables } from '../../variables/glideVariables.js';
+import { createDefinitionAlias } from '../alias.js';
+import FormHandleParam from './form/formHandleParam.js';
+import { GlideParameters, resolveGlideParameterCompletions } from './glideParameters.js';
+import GlideDataUrl from './glideDataUrl.js';
+import GetAllErrors from './getErrors/getAllErrors.js';
+import TaxonomyParameters from './taxonomies/parameters.js';
+
+const sourceParameter: IAntlersParameter = {
+    name: 'src',
+    description: 'The source file or entry point.',
+    aliases: [],
+    acceptsVariableInterpolation: true,
+    allowsVariableReference: true,
+    expectsTypes: ['string', 'array'],
+    isDynamic: false,
+    isRequired: true,
+};
+
+const providerParameter: IAntlersParameter = {
+    name: 'provider',
+    description: 'The OAuth provider to use.',
+    aliases: ['for'],
+    acceptsVariableInterpolation: true,
+    allowsVariableReference: true,
+    expectsTypes: ['string'],
+    isDynamic: false,
+    isRequired: true,
+};
+
+const FormFieldsTag: IAntlersTag = {
+    tagName: 'form:fields',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: false,
+    injectParentScope: true,
+    introducedIn: null,
+    parameters: [
+        FormHandleParam,
+        {
+            name: 'scope',
+            description: 'A prefix applied to each field variable.',
+            aliases: [],
+            acceptsVariableInterpolation: false,
+            allowsVariableReference: false,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'get',
+            description: 'A nested field handle to retrieve.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'only',
+            description: 'A pipe-delimited list of fields to include.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string', 'array'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'except',
+            description: 'A pipe-delimited list of fields to exclude.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string', 'array'],
+            isDynamic: false,
+            isRequired: false,
+        },
+    ],
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables(makeFieldsVariables(node));
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'form:fields Tag',
+        'The `form:fields` tag loops over the renderable fields in the current form.',
+        'https://statamic.dev/tags/form-fields'
+    ),
+};
+
+const GlideGenerateTag: IAntlersTag = {
+    tagName: 'glide:generate',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: false,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: GlideParameters,
+    resovleParameterCompletionItems: resolveGlideParameterCompletions,
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables(makeGlideVariables(node));
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'glide:generate Tag',
+        'The `glide:generate` tag generates an image and exposes its URL and dimensions inside the tag pair.',
+        'https://statamic.dev/tags/glide'
+    ),
+};
+
+const GlideDataUriTag = createDefinitionAlias(GlideDataUrl, 'glide:data_uri');
+GlideDataUriTag.resolveDocumentation = () => makeTagDoc(
+    'glide:data_uri Tag',
+    'The `glide:data_uri` tag is an alias of `glide:data_url`.',
+    'https://statamic.dev/tags/glide'
+);
+
+const ViteContentTag: IAntlersTag = {
+    tagName: 'vite:content',
+    hideFromCompletions: false,
+    requiresClose: false,
+    allowsContentClose: false,
+    allowsArbitraryParameters: false,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [sourceParameter],
+    resolveDocumentation: () => makeTagDoc(
+        'vite:content Tag',
+        'The `vite:content` tag returns the contents of a Vite-managed asset.',
+        'https://statamic.dev/tags/vite'
+    ),
+};
+
+const TaxonomyCountTag: IAntlersTag = {
+    tagName: 'taxonomy:count',
+    hideFromCompletions: false,
+    requiresClose: false,
+    allowsContentClose: false,
+    allowsArbitraryParameters: true,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: TaxonomyParameters,
+    resolveDocumentation: () => makeTagDoc(
+        'taxonomy:count Tag',
+        'The `taxonomy:count` tag returns the number of matching taxonomy terms.',
+        'https://statamic.dev/tags/taxonomy'
+    ),
+};
+
+const ProtectPasswordFormTag: IAntlersTag = {
+    tagName: 'protect:password_form',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: true,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [],
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables([
+            { name: 'errors', dataType: 'array', sourceName: '*internal.protect.password_form', sourceField: null, introducedBy: node },
+            { name: 'error', dataType: 'string', sourceName: '*internal.protect.password_form', sourceField: null, introducedBy: node },
+            { name: 'no_token', dataType: 'boolean', sourceName: '*internal.protect.password_form', sourceField: null, introducedBy: node },
+            { name: 'invalid_token', dataType: 'boolean', sourceName: '*internal.protect.password_form', sourceField: null, introducedBy: node },
+        ]);
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'protect:password_form Tag',
+        'The `protect:password_form` tag renders the form used to unlock password-protected content.',
+        'https://statamic.dev/protecting-content'
+    ),
+};
+
+const OAuthLoginUrlTag: IAntlersTag = {
+    tagName: 'oauth:login_url',
+    hideFromCompletions: false,
+    requiresClose: false,
+    allowsContentClose: false,
+    allowsArbitraryParameters: false,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [
+        providerParameter,
+        {
+            name: 'redirect',
+            description: 'The URL to visit after authentication.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+    ],
+    resovleParameterCompletionItems: (parameter: IAntlersParameter, params: ISuggestionRequest) => {
+        if (parameter.name == 'provider' || parameter.name == 'for') {
+            return exclusiveResultList(params.project.getOAuthProviders());
+        }
+
+        return null;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'oauth:login_url Tag',
+        'The `oauth:login_url` tag generates a login URL for an OAuth provider.',
+        'https://statamic.dev/tags/oauth'
+    ),
+};
+
+const OAuthDisconnectFormTag: IAntlersTag = {
+    tagName: 'oauth:disconnect_form',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: true,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [providerParameter],
+    resovleParameterCompletionItems: OAuthLoginUrlTag.resovleParameterCompletionItems,
+    resolveDocumentation: () => makeTagDoc(
+        'oauth:disconnect_form Tag',
+        'The `oauth:disconnect_form` tag renders a form that disconnects an OAuth provider from the current user.',
+        'https://statamic.dev/tags/oauth'
+    ),
+};
+
+const GetErrorAllTag = createDefinitionAlias(GetAllErrors, 'get_error:all');
+GetErrorAllTag.resolveDocumentation = () => makeTagDoc(
+    'get_error:all Tag',
+    'The `get_error:all` tag retrieves every validation error message.',
+    'https://statamic.dev/tags/get_errors'
+);
+
+export {
+    FormFieldsTag,
+    GetErrorAllTag,
+    GlideDataUriTag,
+    GlideGenerateTag,
+    OAuthDisconnectFormTag,
+    OAuthLoginUrlTag,
+    ProtectPasswordFormTag,
+    TaxonomyCountTag,
+    ViteContentTag,
+};

--- a/server/src/antlers/tags/core/form/form.ts
+++ b/server/src/antlers/tags/core/form/form.ts
@@ -9,6 +9,7 @@ import FormSubmission from './formSubmission.js';
 import FormSubmissions from './formSubmissions.js';
 import FormSuccess from './formSuccess.js';
 import { resolveFormParameterCompletions } from "./parameterCompletions.js";
+import { FormFieldsTag } from '../additionalTagMethods.js';
 
 const FormCompletions: CompletionItem[] = [
     tagToCompletionItem(FormSetTag),
@@ -16,7 +17,8 @@ const FormCompletions: CompletionItem[] = [
     tagToCompletionItem(FormErrors),
     tagToCompletionItem(FormSuccess),
     tagToCompletionItem(FormSubmissions),
-    tagToCompletionItem(FormSubmission)
+    tagToCompletionItem(FormSubmission),
+    tagToCompletionItem(FormFieldsTag)
 ];
 
 const FormTag: IAntlersTag = {

--- a/server/src/antlers/tags/core/glide.ts
+++ b/server/src/antlers/tags/core/glide.ts
@@ -14,10 +14,13 @@ import { makeGlideVariables } from "../../variables/glideVariables.js";
 import GlideBatch from './glideBatch.js';
 import GlideDataUrl from './glideDataUrl.js';
 import { GlideParameters, resolveGlideParameterCompletions } from './glideParameters.js';
+import { GlideDataUriTag, GlideGenerateTag } from './additionalTagMethods.js';
 
 const GlideCompletionItems: CompletionItem[] = [
     tagToCompletionItem(GlideBatch),
-    tagToCompletionItem(GlideDataUrl)
+    tagToCompletionItem(GlideDataUrl),
+    tagToCompletionItem(GlideDataUriTag),
+    tagToCompletionItem(GlideGenerateTag)
 ];
 
 const Glide: IAntlersTag = {

--- a/server/src/antlers/tags/core/glideDataUrl.ts
+++ b/server/src/antlers/tags/core/glideDataUrl.ts
@@ -6,7 +6,7 @@ import { GlideParameters, resolveGlideParameterCompletions } from './glideParame
 const GlideDataUrl: IAntlersTag = {
     tagName: 'glide:data_url',
     hideFromCompletions: false,
-    requiresClose: true,
+    requiresClose: false,
     allowsContentClose: false,
     allowsArbitraryParameters: false,
     injectParentScope: false,

--- a/server/src/antlers/tags/core/memberUserAliases.ts
+++ b/server/src/antlers/tags/core/memberUserAliases.ts
@@ -3,23 +3,29 @@ import { ISuggestionRequest } from '../../../suggestions/suggestionRequest.js';
 import { createDefinitionAlias } from '../alias.js';
 import User from './user.js';
 import UserCan from './userCan.js';
+import UserCant from './userCant.js';
 import UserIn from './userIn.js';
 import UserIs from './userIs.js';
 import UserIsnt from './userIsnt.js';
 import UserLogout from './userLogout.js';
 import UserLogoutUrl from './userLogoutUrl.js';
 import UserNotIn from './userNotIn.js';
+import UserPasswordForm from './userPasswordForm.js';
 import UserProfile from './userProfile.js';
+import UserProfileForm from './userProfileForm.js';
 
 const MemberTag = createDefinitionAlias(User, 'member'),
     MemberIs = createDefinitionAlias(UserIs, 'member:is'),
     MemberIsnt = createDefinitionAlias(UserIsnt, 'member:isnt'),
     MemberProfile = createDefinitionAlias(UserProfile, 'member:profile'),
     MemberCan = createDefinitionAlias(UserCan, 'member:can'),
+    MemberCant = createDefinitionAlias(UserCant, 'member:cant'),
     MemberLogout = createDefinitionAlias(UserLogout, 'member:logout'),
     MemberLogoutUrl = createDefinitionAlias(UserLogoutUrl, 'member:logout_url'),
     MemberIn = createDefinitionAlias(UserIn, 'member:in'),
-    MemberNotIn = createDefinitionAlias(UserNotIn, 'member:not_in');
+    MemberNotIn = createDefinitionAlias(UserNotIn, 'member:not_in'),
+    MemberPasswordForm = createDefinitionAlias(UserPasswordForm, 'member:password_form'),
+    MemberProfileForm = createDefinitionAlias(UserProfileForm, 'member:profile_form');
 
 MemberTag.hideFromCompletions = true;
 
@@ -98,5 +104,6 @@ MemberNotIn.resolveDocumentation = (params?: ISuggestionRequest) => {
 
 export {
     MemberTag, MemberIs, MemberIsnt, MemberProfile,
-    MemberCan, MemberLogout, MemberLogoutUrl, MemberIn, MemberNotIn
+    MemberCan, MemberCant, MemberLogout, MemberLogoutUrl, MemberIn, MemberNotIn,
+    MemberPasswordForm, MemberProfileForm
 };

--- a/server/src/antlers/tags/core/oauth.ts
+++ b/server/src/antlers/tags/core/oauth.ts
@@ -1,6 +1,16 @@
+import { CompletionItem } from 'vscode-languageserver-types';
 import { makeTagDocWithCodeSample } from '../../../documentation/utils.js';
+import { AntlersNode } from '../../../runtime/nodes/abstractNode.js';
 import { ISuggestionRequest } from '../../../suggestions/suggestionRequest.js';
-import { exclusiveResultList, IAntlersParameter, IAntlersTag } from '../../tagManager.js';
+import { tagToCompletionItem } from '../../documentedLabel.js';
+import { Scope } from '../../scope/scope.js';
+import { EmptyCompletionResult, exclusiveResult, exclusiveResultList, IAntlersParameter, IAntlersTag } from '../../tagManager.js';
+import { OAuthDisconnectFormTag, OAuthLoginUrlTag } from './additionalTagMethods.js';
+
+const OAuthCompletionItems: CompletionItem[] = [
+    tagToCompletionItem(OAuthLoginUrlTag),
+    tagToCompletionItem(OAuthDisconnectFormTag),
+];
 
 const OAuth: IAntlersTag = {
     tagName: 'oauth',
@@ -8,13 +18,13 @@ const OAuth: IAntlersTag = {
     injectParentScope: false,
     requiresClose: false,
     allowsArbitraryParameters: false,
-    allowsContentClose: false,
+    allowsContentClose: true,
     introducedIn: null,
     parameters: [{
         name: 'provider',
         description: 'The OAuth provider to be used.',
         aliases: [],
-        isRequired: true,
+        isRequired: false,
         acceptsVariableInterpolation: true,
         allowsVariableReference: false,
         isDynamic: false,
@@ -23,7 +33,7 @@ const OAuth: IAntlersTag = {
         name: 'redirect',
         description: 'The URL to be redirected to after authenticating.',
         aliases: [],
-        isRequired: true,
+        isRequired: false,
         acceptsVariableInterpolation: true,
         allowsVariableReference: false,
         isDynamic: false,
@@ -35,6 +45,27 @@ const OAuth: IAntlersTag = {
         }
 
         return null;
+    },
+    resolveCompletionItems: (params: ISuggestionRequest) => {
+        if (
+            params.isPastTagPart == false &&
+            (params.leftWord == 'oauth' || params.leftWord == '/oauth') &&
+            params.leftChar == ':'
+        ) {
+            return exclusiveResult(OAuthCompletionItems);
+        }
+
+        return EmptyCompletionResult;
+    },
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables([
+            { name: 'name', dataType: 'string', sourceName: '*internal.oauth', sourceField: null, introducedBy: node },
+            { name: 'label', dataType: 'string', sourceName: '*internal.oauth', sourceField: null, introducedBy: node },
+            { name: 'connected', dataType: 'boolean', sourceName: '*internal.oauth', sourceField: null, introducedBy: node },
+            { name: 'url', dataType: 'string', sourceName: '*internal.oauth', sourceField: null, introducedBy: node },
+        ]);
+
+        return scope;
     },
     resolveDocumentation: (params?: ISuggestionRequest) => {
         return makeTagDocWithCodeSample(

--- a/server/src/antlers/tags/core/siteTags.ts
+++ b/server/src/antlers/tags/core/siteTags.ts
@@ -1,0 +1,318 @@
+import { CompletionItem, CompletionItemKind } from 'vscode-languageserver-types';
+import { makeTagDoc } from '../../../documentation/utils.js';
+import { AntlersNode } from '../../../runtime/nodes/abstractNode.js';
+import { ISuggestionRequest } from '../../../suggestions/suggestionRequest.js';
+import { Scope } from '../../scope/scope.js';
+import {
+    EmptyCompletionResult,
+    exclusiveResult,
+    exclusiveResultList,
+    IAntlersParameter,
+    IAntlersTag,
+    nonExclusiveResult,
+} from '../../tagManager.js';
+import { createDefinitionAlias } from '../alias.js';
+import { returnDynamicParameter } from '../dynamicParameterResolver.js';
+import { StructureTag } from './nav/nav.js';
+
+const queryParameters: IAntlersParameter[] = [
+    {
+        name: 'sort',
+        description: 'The field and direction used to sort the results.',
+        aliases: [],
+        acceptsVariableInterpolation: true,
+        allowsVariableReference: true,
+        expectsTypes: ['string'],
+        isDynamic: false,
+        isRequired: false,
+    },
+    {
+        name: 'limit',
+        description: 'The maximum number of results to return.',
+        aliases: [],
+        acceptsVariableInterpolation: false,
+        allowsVariableReference: true,
+        expectsTypes: ['number'],
+        isDynamic: false,
+        isRequired: false,
+    },
+    {
+        name: 'offset',
+        description: 'The number of results to skip.',
+        aliases: [],
+        acceptsVariableInterpolation: false,
+        allowsVariableReference: true,
+        expectsTypes: ['number'],
+        isDynamic: false,
+        isRequired: false,
+    },
+    {
+        name: 'paginate',
+        description: 'Whether the results should be paginated.',
+        aliases: [],
+        acceptsVariableInterpolation: false,
+        allowsVariableReference: true,
+        expectsTypes: ['boolean', 'number'],
+        isDynamic: false,
+        isRequired: false,
+    },
+    {
+        name: 'as',
+        description: 'The variable name used to expose the results.',
+        aliases: [],
+        acceptsVariableInterpolation: false,
+        allowsVariableReference: false,
+        expectsTypes: ['string'],
+        isDynamic: false,
+        isRequired: false,
+    },
+    {
+        name: 'filter',
+        description: 'The query scope used to filter the results.',
+        aliases: ['query_scope'],
+        acceptsVariableInterpolation: true,
+        allowsVariableReference: true,
+        expectsTypes: ['string'],
+        isDynamic: false,
+        isRequired: false,
+    },
+];
+
+const CanTag: IAntlersTag = {
+    tagName: 'can',
+    hideFromCompletions: false,
+    requiresClose: false,
+    allowsContentClose: true,
+    allowsArbitraryParameters: false,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [
+        {
+            name: 'permission',
+            description: 'The permission the current user must have.',
+            aliases: ['do'],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string', 'array'],
+            isDynamic: false,
+            isRequired: false,
+        },
+    ],
+    resolveDocumentation: () => makeTagDoc(
+        'can Tag',
+        'The `can` tag renders its contents when the current user has the requested permission.',
+        'https://statamic.dev/tags/can'
+    ),
+};
+
+const ChildrenTag = createDefinitionAlias(StructureTag, 'children');
+ChildrenTag.parameters = [
+    ...StructureTag.parameters,
+    {
+        name: 'of',
+        description: 'The URL whose direct children should be returned.',
+        aliases: [],
+        acceptsVariableInterpolation: true,
+        allowsVariableReference: true,
+        expectsTypes: ['string'],
+        isDynamic: false,
+        isRequired: false,
+    },
+];
+ChildrenTag.resolveCompletionItems = () => EmptyCompletionResult;
+ChildrenTag.resolveDocumentation = () => makeTagDoc(
+    'children Tag',
+    'The `children` tag returns the direct children of the current URL or a URL supplied with the `of` parameter.',
+    'https://statamic.dev/tags/children'
+);
+
+const DictionaryTag: IAntlersTag = {
+    tagName: 'dictionary',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: true,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [
+        {
+            name: 'handle',
+            description: 'The dictionary handle to query.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'search',
+            description: 'A value used to search the dictionary options.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        ...queryParameters,
+    ],
+    resolveDynamicParameter: returnDynamicParameter,
+    resolveCompletionItems: (params: ISuggestionRequest) => {
+        if (
+            params.isPastTagPart == false &&
+            (params.leftWord == 'dictionary' || params.leftWord == '/dictionary') &&
+            params.leftChar == ':'
+        ) {
+            return nonExclusiveResult([
+                'countries',
+                'currencies',
+                'file',
+                'languages',
+                'locales',
+                'timezones',
+            ].map((label): CompletionItem => ({ label, kind: CompletionItemKind.Field })));
+        }
+
+        return EmptyCompletionResult;
+    },
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables([
+            { name: 'value', dataType: 'string', sourceName: '*internal.dictionary', sourceField: null, introducedBy: node },
+            { name: 'label', dataType: 'string', sourceName: '*internal.dictionary', sourceField: null, introducedBy: node },
+        ]);
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'dictionary Tag',
+        'The `dictionary` tag queries options from a registered dictionary.',
+        'https://statamic.dev/tags/dictionary'
+    ),
+};
+
+const GetSiteTag: IAntlersTag = {
+    tagName: 'get_site',
+    hideFromCompletions: false,
+    requiresClose: false,
+    allowsContentClose: true,
+    allowsArbitraryParameters: false,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [
+        {
+            name: 'handle',
+            description: 'The handle of the site to retrieve.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'as',
+            description: 'The variable name used to expose the site data.',
+            aliases: [],
+            acceptsVariableInterpolation: false,
+            allowsVariableReference: false,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: false,
+        },
+    ],
+    resovleParameterCompletionItems: (parameter: IAntlersParameter, params: ISuggestionRequest) => {
+        if (parameter.name == 'handle') {
+            return exclusiveResultList(params.project.getSiteNames());
+        }
+
+        return null;
+    },
+    resolveCompletionItems: (params: ISuggestionRequest) => {
+        if (
+            params.isPastTagPart == false &&
+            (params.leftWord == 'get_site' || params.leftWord == '/get_site') &&
+            params.leftChar == ':'
+        ) {
+            return exclusiveResult(params.project.getSiteNames().map((label): CompletionItem => ({
+                label,
+                kind: CompletionItemKind.Field,
+            })));
+        }
+
+        return EmptyCompletionResult;
+    },
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.addVariables([
+            { name: 'handle', dataType: 'string', sourceName: '*internal.site', sourceField: null, introducedBy: node },
+            { name: 'name', dataType: 'string', sourceName: '*internal.site', sourceField: null, introducedBy: node },
+            { name: 'locale', dataType: 'string', sourceName: '*internal.site', sourceField: null, introducedBy: node },
+            { name: 'short_locale', dataType: 'string', sourceName: '*internal.site', sourceField: null, introducedBy: node },
+            { name: 'url', dataType: 'string', sourceName: '*internal.site', sourceField: null, introducedBy: node },
+        ]);
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'get_site Tag',
+        'The `get_site` tag retrieves data for a specific site in a multisite installation.',
+        'https://statamic.dev/tags/get_site'
+    ),
+};
+
+const UsersTag: IAntlersTag = {
+    tagName: 'users',
+    hideFromCompletions: false,
+    requiresClose: true,
+    allowsContentClose: false,
+    allowsArbitraryParameters: true,
+    injectParentScope: false,
+    introducedIn: null,
+    parameters: [
+        {
+            name: 'group',
+            description: 'The user groups to include.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string', 'array'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        {
+            name: 'role',
+            description: 'The user roles to include.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string', 'array'],
+            isDynamic: false,
+            isRequired: false,
+        },
+        ...queryParameters,
+    ],
+    resolveDynamicParameter: returnDynamicParameter,
+    resovleParameterCompletionItems: (parameter: IAntlersParameter, params: ISuggestionRequest) => {
+        if (parameter.name == 'group') {
+            return exclusiveResultList(params.project.getUniqueUserGroupNames());
+        }
+
+        if (parameter.name == 'role') {
+            return exclusiveResultList(params.project.getUniqueUserRoleNames());
+        }
+
+        return null;
+    },
+    augmentScope: (node: AntlersNode, scope: Scope) => {
+        scope.injectUserFields(node);
+
+        return scope;
+    },
+    resolveDocumentation: () => makeTagDoc(
+        'users Tag',
+        'The `users` tag queries and loops over users.',
+        'https://statamic.dev/tags/users'
+    ),
+};
+
+export { CanTag, ChildrenTag, DictionaryTag, GetSiteTag, UsersTag };

--- a/server/src/antlers/tags/core/user.ts
+++ b/server/src/antlers/tags/core/user.ts
@@ -17,10 +17,12 @@ import {
 import UserCan from './userCan.js';
 import UserCant from './userCant.js';
 import { UserForgotPasswordForm } from './userForgotPasswordForm.js';
+import UserIn from './userIn.js';
 import UserIs from './userIs.js';
 import UserIsnt from './userIsnt.js';
 import UserLogout from './userLogout.js';
 import UserLogoutUrl from './userLogoutUrl.js';
+import { UserLoginForm } from './userLoginForm.js';
 import UserNotIn from './userNotIn.js';
 import UserPasswordForm from './userPasswordForm.js';
 import { UserPasswordReset } from './userPasswordReset.js';
@@ -28,12 +30,15 @@ import UserProfile from './userProfile.js';
 import UserProfileForm from './userProfileForm.js';
 import { UserProfileParameters } from './userProfileParameters.js';
 import { UserRegister } from './userRegister.js';
+import { userSecurityTags } from './userSecurityTags.js';
 
 const UserTagCompletionItems: CompletionItem[] = [
     tagToCompletionItem(UserIs),
+    tagToCompletionItem(UserIn),
     tagToCompletionItem(UserNotIn),
     tagToCompletionItem(UserIsnt),
     tagToCompletionItem(UserProfile),
+    tagToCompletionItem(UserLoginForm),
     tagToCompletionItem(UserCan),
     tagToCompletionItem(UserCant),
     tagToCompletionItem(UserForgotPasswordForm),
@@ -43,6 +48,7 @@ const UserTagCompletionItems: CompletionItem[] = [
     tagToCompletionItem(UserPasswordReset),
     tagToCompletionItem(UserProfileForm),
     tagToCompletionItem(UserPasswordForm),
+    ...userSecurityTags.map(tagToCompletionItem),
 ];
 
 const User: IAntlersTag = {

--- a/server/src/antlers/tags/core/userSecurityTags.ts
+++ b/server/src/antlers/tags/core/userSecurityTags.ts
@@ -1,0 +1,274 @@
+import { makeTagDoc } from '../../../documentation/utils.js';
+import { AntlersNode } from '../../../runtime/nodes/abstractNode.js';
+import { Scope } from '../../scope/scope.js';
+import { IScopeVariable } from '../../scope/types.js';
+import { IAntlersParameter, IAntlersTag } from '../../tagManager.js';
+import { makeStandardFormVariables } from '../../variables/forms/standardFormVariables.js';
+import { createDefinitionAlias } from '../alias.js';
+import { UserRegister } from './userRegister.js';
+
+interface IUserTagOptions {
+    method: string;
+    description: string;
+    requiresClose: boolean;
+    parameters?: IAntlersParameter[];
+    scopeVariables?: Array<{ name: string; dataType: string }>;
+    isForm?: boolean;
+    allowsArbitraryParameters?: boolean;
+}
+
+const redirectParameter: IAntlersParameter = {
+    name: 'redirect',
+    description: 'The URL to visit after a successful request.',
+    aliases: [],
+    acceptsVariableInterpolation: true,
+    allowsVariableReference: true,
+    expectsTypes: ['string'],
+    isDynamic: false,
+    isRequired: false,
+};
+
+const errorRedirectParameter: IAntlersParameter = {
+    name: 'error_redirect',
+    description: 'The URL to visit after a failed request.',
+    aliases: [],
+    acceptsVariableInterpolation: true,
+    allowsVariableReference: true,
+    expectsTypes: ['string'],
+    isDynamic: false,
+    isRequired: false,
+};
+
+const allowRequestRedirectParameter: IAntlersParameter = {
+    name: 'allow_request_redirect',
+    description: 'Whether request parameters may override redirect values.',
+    aliases: [],
+    acceptsVariableInterpolation: false,
+    allowsVariableReference: true,
+    expectsTypes: ['boolean'],
+    isDynamic: false,
+    isRequired: false,
+};
+
+const standardFormParameters = [
+    redirectParameter,
+    errorRedirectParameter,
+    allowRequestRedirectParameter,
+];
+
+function makeUserTag(options: IUserTagOptions): IAntlersTag {
+    const tag: IAntlersTag = {
+        tagName: `user:${options.method}`,
+        hideFromCompletions: false,
+        requiresClose: options.requiresClose,
+        allowsContentClose: false,
+        allowsArbitraryParameters: options.allowsArbitraryParameters ?? false,
+        injectParentScope: false,
+        introducedIn: null,
+        parameters: options.parameters ?? [],
+        resolveDocumentation: () => makeTagDoc(
+            `user:${options.method} Tag`,
+            options.description,
+            'https://statamic.dev/tags/user'
+        ),
+    };
+
+    if (options.isForm || (options.scopeVariables?.length ?? 0) > 0) {
+        tag.augmentScope = (node: AntlersNode, scope: Scope) => {
+            if (options.isForm) {
+                scope.addVariables(makeStandardFormVariables(node));
+            }
+
+            if (options.scopeVariables != null) {
+                const variables: IScopeVariable[] = options.scopeVariables.map((variable) => ({
+                    name: variable.name,
+                    dataType: variable.dataType,
+                    sourceName: `*internal.user.${options.method}`,
+                    sourceField: null,
+                    introducedBy: node,
+                }));
+
+                scope.addVariables(variables);
+            }
+
+            return scope;
+        };
+    }
+
+    return tag;
+}
+
+const UserRegistrationForm = createDefinitionAlias(UserRegister, 'user:registration_form');
+UserRegistrationForm.resolveDocumentation = () => makeTagDoc(
+    'user:registration_form Tag',
+    'The `user:registration_form` tag is an alias of `user:register_form`.',
+    'https://statamic.dev/tags/user-register_form'
+);
+
+const UserPasskeyForm = makeUserTag({
+    method: 'passkey_form',
+    description: 'The `user:passkey_form` tag exposes the URLs needed to register a passkey.',
+    requiresClose: true,
+    scopeVariables: [
+        { name: 'passkey_options_url', dataType: 'string' },
+        { name: 'passkey_verify_url', dataType: 'string' },
+    ],
+});
+
+const UserPasskeys = makeUserTag({
+    method: 'passkeys',
+    description: 'The `user:passkeys` tag loops over the current user\'s registered passkeys.',
+    requiresClose: true,
+    scopeVariables: [
+        { name: 'id', dataType: 'string' },
+        { name: 'name', dataType: 'string' },
+        { name: 'last_login', dataType: 'date' },
+    ],
+});
+
+const UserDeletePasskeyForm = makeUserTag({
+    method: 'delete_passkey_form',
+    description: 'The `user:delete_passkey_form` tag renders a form that removes a registered passkey.',
+    requiresClose: true,
+    isForm: true,
+    allowsArbitraryParameters: true,
+    parameters: [
+        {
+            name: 'id',
+            description: 'The ID of the passkey to remove.',
+            aliases: [],
+            acceptsVariableInterpolation: true,
+            allowsVariableReference: true,
+            expectsTypes: ['string'],
+            isDynamic: false,
+            isRequired: true,
+        },
+        redirectParameter,
+    ],
+});
+
+const UserElevatedSessionForm = makeUserTag({
+    method: 'elevated_session_form',
+    description: 'The `user:elevated_session_form` tag renders the form used to confirm an elevated session.',
+    requiresClose: true,
+    isForm: true,
+    allowsArbitraryParameters: true,
+    scopeVariables: [
+        { name: 'method', dataType: 'string' },
+        { name: 'allow_passkey', dataType: 'boolean' },
+        { name: 'resend_code_url', dataType: 'string' },
+        { name: 'passkey_options_url', dataType: 'string' },
+        { name: 'submit_url', dataType: 'string' },
+    ],
+});
+
+const UserTwoFactorEnabled = makeUserTag({
+    method: 'two_factor_enabled',
+    description: 'The `user:two_factor_enabled` tag reports whether the current user has two-factor authentication enabled.',
+    requiresClose: false,
+});
+
+const UserTwoFactorChallengeForm = makeUserTag({
+    method: 'two_factor_challenge_form',
+    description: 'The `user:two_factor_challenge_form` tag renders the two-factor login challenge form.',
+    requiresClose: true,
+    parameters: standardFormParameters,
+    isForm: true,
+    allowsArbitraryParameters: true,
+});
+
+const UserTwoFactorEnableForm = makeUserTag({
+    method: 'two_factor_enable_form',
+    description: 'The `user:two_factor_enable_form` tag renders the form that begins two-factor setup.',
+    requiresClose: true,
+    parameters: [redirectParameter, allowRequestRedirectParameter],
+    isForm: true,
+    allowsArbitraryParameters: true,
+});
+
+const UserTwoFactorSetupForm = makeUserTag({
+    method: 'two_factor_setup_form',
+    description: 'The `user:two_factor_setup_form` tag renders the form that confirms two-factor setup.',
+    requiresClose: true,
+    parameters: standardFormParameters,
+    isForm: true,
+    allowsArbitraryParameters: true,
+    scopeVariables: [
+        { name: 'qr_code', dataType: 'string' },
+        { name: 'qr_code_url', dataType: 'string' },
+        { name: 'secret_key', dataType: 'string' },
+    ],
+});
+
+const UserTwoFactorRecoveryCodes = makeUserTag({
+    method: 'two_factor_recovery_codes',
+    description: 'The `user:two_factor_recovery_codes` tag loops over the current user\'s recovery codes.',
+    requiresClose: true,
+    scopeVariables: [{ name: 'code', dataType: 'string' }],
+});
+
+const UserTwoFactorRecoveryCodesDownloadUrl = makeUserTag({
+    method: 'two_factor_recovery_codes_download_url',
+    description: 'The `user:two_factor_recovery_codes_download_url` tag returns the recovery-code download URL.',
+    requiresClose: false,
+});
+
+const UserResetTwoFactorRecoveryCodesForm = makeUserTag({
+    method: 'reset_two_factor_recovery_codes_form',
+    description: 'The `user:reset_two_factor_recovery_codes_form` tag renders the recovery-code reset form.',
+    requiresClose: true,
+    parameters: [redirectParameter, allowRequestRedirectParameter],
+    isForm: true,
+    allowsArbitraryParameters: true,
+});
+
+const UserDisableTwoFactorForm = makeUserTag({
+    method: 'disable_two_factor_form',
+    description: 'The `user:disable_two_factor_form` tag renders the form that disables two-factor authentication.',
+    requiresClose: true,
+    parameters: [redirectParameter, allowRequestRedirectParameter],
+    isForm: true,
+    allowsArbitraryParameters: true,
+});
+
+const userSecurityTags = [
+    UserRegistrationForm,
+    UserPasskeyForm,
+    UserPasskeys,
+    UserDeletePasskeyForm,
+    UserElevatedSessionForm,
+    UserTwoFactorEnabled,
+    UserTwoFactorChallengeForm,
+    UserTwoFactorEnableForm,
+    UserTwoFactorSetupForm,
+    UserTwoFactorRecoveryCodes,
+    UserTwoFactorRecoveryCodesDownloadUrl,
+    UserResetTwoFactorRecoveryCodesForm,
+    UserDisableTwoFactorForm,
+];
+
+const memberSecurityTags = userSecurityTags.map((tag) => {
+    const alias = createDefinitionAlias(tag, tag.tagName.replace(/^user:/, 'member:'));
+
+    alias.resolveDocumentation = () => tag.resolveDocumentation?.().replace(/user:/g, 'member:') ?? '';
+
+    return alias;
+});
+
+export {
+    memberSecurityTags,
+    UserDeletePasskeyForm,
+    UserDisableTwoFactorForm,
+    UserElevatedSessionForm,
+    UserPasskeyForm,
+    UserPasskeys,
+    UserRegistrationForm,
+    UserResetTwoFactorRecoveryCodesForm,
+    userSecurityTags,
+    UserTwoFactorChallengeForm,
+    UserTwoFactorEnabled,
+    UserTwoFactorEnableForm,
+    UserTwoFactorRecoveryCodes,
+    UserTwoFactorRecoveryCodesDownloadUrl,
+    UserTwoFactorSetupForm,
+};

--- a/server/src/antlers/tags/core/vite.ts
+++ b/server/src/antlers/tags/core/vite.ts
@@ -4,15 +4,17 @@ import { ISuggestionRequest } from '../../../suggestions/suggestionRequest.js';
 import { EmptyCompletionResult, IAntlersTag, exclusiveResult } from '../../tagManager.js';
 import { tagToCompletionItem } from '../../documentedLabel.js';
 import ViteAsset from './vite/viteAsset.js';
+import { ViteContentTag } from './additionalTagMethods.js';
 
 const ViteTagCompletionItems: CompletionItem[] = [
-    tagToCompletionItem(ViteAsset)
+    tagToCompletionItem(ViteAsset),
+    tagToCompletionItem(ViteContentTag)
 ];
 
 const Vite: IAntlersTag = {
     tagName: 'vite',
     hideFromCompletions: false,
-    requiresClose: true,
+    requiresClose: false,
     injectParentScope: false,
     allowsContentClose: false,
     allowsArbitraryParameters: false,

--- a/server/src/antlers/tags/core/vite/viteAsset.ts
+++ b/server/src/antlers/tags/core/vite/viteAsset.ts
@@ -5,7 +5,7 @@ import { IAntlersTag } from '../../../tagManager.js';
 const ViteAsset: IAntlersTag = {
     tagName: 'vite:asset',
     hideFromCompletions: false,
-    requiresClose: true,
+    requiresClose: false,
     injectParentScope: false,
     allowsContentClose: false,
     allowsArbitraryParameters: false,

--- a/server/src/antlers/tags/coreTags.ts
+++ b/server/src/antlers/tags/coreTags.ts
@@ -68,13 +68,16 @@ import {
 } from "./core/collection/ageDirectional.js";
 import {
     MemberCan,
+    MemberCant,
     MemberIn,
     MemberIs,
     MemberIsnt,
     MemberLogout,
     MemberLogoutUrl,
     MemberNotIn,
+    MemberPasswordForm,
     MemberProfile,
+    MemberProfileForm,
     MemberTag,
 } from "./core/memberUserAliases.js";
 import TaxonomyTag from "./core/taxonomies/taxonomy.js";
@@ -124,6 +127,19 @@ import CookieValue from './core/cookie/cookieValue.js';
 import UserProfileForm from './core/userProfileForm.js';
 import UserPasswordForm from './core/userPasswordForm.js';
 import ViteAsset from './core/vite/viteAsset.js';
+import {
+    FormFieldsTag,
+    GetErrorAllTag,
+    GlideDataUriTag,
+    GlideGenerateTag,
+    OAuthDisconnectFormTag,
+    OAuthLoginUrlTag,
+    ProtectPasswordFormTag,
+    TaxonomyCountTag,
+    ViteContentTag,
+} from './core/additionalTagMethods.js';
+import { CanTag, ChildrenTag, DictionaryTag, GetSiteTag, UsersTag } from './core/siteTags.js';
+import { memberSecurityTags, userSecurityTags } from './core/userSecurityTags.js';
 
 const coreTags = [
     If,
@@ -134,6 +150,8 @@ const coreTags = [
 
     Asset,
     Assets,
+    CanTag,
+    ChildrenTag,
     Collection,
     CollectionCount,
     CollectionPrevious,
@@ -147,6 +165,8 @@ const coreTags = [
     CookieSet,
     CookieValue,
 
+    DictionaryTag,
+
     Relate,
 
     FormTag,
@@ -158,12 +178,15 @@ const coreTags = [
     FormSetTag,
     FormSuccess,
     FormErrors,
+    FormFieldsTag,
 
     SetTag,
 
     GetErrors,
     GetError,
     GetAllErrors,
+    GetErrorAllTag,
+    GetSiteTag,
 
     BaseSearchTag,
     SearchResultsTag,
@@ -184,6 +207,8 @@ const coreTags = [
     Glide,
     GlideBatch,
     GlideDataUrl,
+    GlideDataUriTag,
+    GlideGenerateTag,
     Link,
     Loop,
     RangeTag,
@@ -224,20 +249,25 @@ const coreTags = [
     UserProfileForm,
     UserPasswordForm,
     UserRegister,
+    ...userSecurityTags,
 
     MemberTag,
     MemberIs,
     MemberIsnt,
     MemberProfile,
     MemberCan,
+    MemberCant,
     MemberLogout,
     MemberLogoutUrl,
     MemberIn,
     MemberNotIn,
+    MemberPasswordForm,
+    MemberProfileForm,
     MemberLoginForm,
     MemberPasswordReset,
     MemberForgotPasswordForm,
     MemberRegister,
+    ...memberSecurityTags,
 
     NoParse,
     NoCache,
@@ -245,6 +275,8 @@ const coreTags = [
     Switch,
     Rotate,
     OAuth,
+    OAuthLoginUrlTag,
+    OAuthDisconnectFormTag,
     Obfuscate,
     Parent,
     PathTag,
@@ -261,6 +293,8 @@ const coreTags = [
     SessionDump,
     SVGTag,
     TaxonomyTag,
+    TaxonomyCountTag,
+    ProtectPasswordFormTag,
     Theme,
     ThemePath,
     ThemeAsset,
@@ -277,7 +311,9 @@ const coreTags = [
     MarkdownIndent,
     Widont,
     Vite,
-    ViteAsset
+    ViteAsset,
+    ViteContentTag,
+    UsersTag
 ];
 
 export { coreTags };

--- a/server/src/providers/providerParameters.ts
+++ b/server/src/providers/providerParameters.ts
@@ -1,6 +1,8 @@
 import { Position } from "vscode-languageserver-textdocument";
 import { sessionDocuments } from '../languageService/documents.js';
 import ProjectManager from '../projects/projectManager.js';
+import { IProjectDetailsProvider } from '../projects/projectDetailsProvider.js';
+import { AntlersDocument } from '../runtime/document/antlersDocument.js';
 import { AntlersNode } from '../runtime/nodes/abstractNode.js';
 import { ISuggestionRequest } from '../suggestions/suggestionRequest.js';
 import * as antlr from '../runtime/nodes/position.js';
@@ -55,12 +57,26 @@ export function makeProviderRequest(
         return null;
     }
 
-    const document = sessionDocuments.getDocument(documentUri),
-        targetLine = position.line + 1,
+    return makeProviderRequestForDocument(
+        position,
+        documentUri,
+        sessionDocuments.getDocument(documentUri),
+        ProjectManager.instance.getStructure(),
+        showGeneralSnippetCompletions
+    );
+}
+
+export function makeProviderRequestForDocument(
+    position: Position,
+    documentUri: string,
+    document: AntlersDocument,
+    activeStructure: IProjectDetailsProvider,
+    showGeneralSnippetCompletions = true
+): ISuggestionRequest {
+    const targetLine = position.line + 1,
         targetChar = position.character + 1,
         features = document.cursor.getFeaturesAt(targetLine, targetChar),
         targetPos = document.cursor.position(targetLine, targetChar),
-        activeStructure = ProjectManager.instance.getStructure(),
         scopeAncestors = document.cursor.getAncestorsAt(targetLine, targetChar);
 
     if (targetPos != null && scopeAncestors.length > 0) {

--- a/server/src/services/antlersCompletion.ts
+++ b/server/src/services/antlersCompletion.ts
@@ -46,7 +46,8 @@ export function handleOnCompletion(_textDocumentPosition: TextDocumentPositionPa
     const componentSuggestions = getAntlersComponentSuggestions(
         suggestionRequest.antlersDocument.getOriginalContent(),
         suggestionRequest.position,
-        suggestionRequest.project
+        suggestionRequest.project,
+        suggestionRequest
     );
     const directiveSuggestions = componentSuggestions == null
         ? getAntlersDirectiveSuggestions(

--- a/server/src/services/antlersCompletion.ts
+++ b/server/src/services/antlersCompletion.ts
@@ -7,6 +7,7 @@ import ProjectManager from '../projects/projectManager.js';
 import { makeProviderRequest } from "../providers/providerParameters.js";
 import { globalSettings } from '../server.js';
 import { getAntlersComponentSuggestions } from '../suggestions/antlersComponentSuggestions.js';
+import { getAntlersDirectiveSuggestions } from '../suggestions/antlersDirectiveSuggestions.js';
 import { SuggestionManager } from "../suggestions/suggestionManager.js";
 
 interface ICompletionDetail {
@@ -47,8 +48,14 @@ export function handleOnCompletion(_textDocumentPosition: TextDocumentPositionPa
         suggestionRequest.position,
         suggestionRequest.project
     );
+    const directiveSuggestions = componentSuggestions == null
+        ? getAntlersDirectiveSuggestions(
+            suggestionRequest.antlersDocument.getOriginalContent(),
+            suggestionRequest.position
+        )
+        : null;
 
-    let suggestions = componentSuggestions ?? SuggestionManager.getSuggestions(suggestionRequest);
+    let suggestions = componentSuggestions ?? directiveSuggestions ?? SuggestionManager.getSuggestions(suggestionRequest);
 
     const returnedItems: string[] = [];
 

--- a/server/src/services/antlersCompletion.ts
+++ b/server/src/services/antlersCompletion.ts
@@ -6,7 +6,7 @@ import { sessionDocuments } from '../languageService/documents.js';
 import ProjectManager from '../projects/projectManager.js';
 import { makeProviderRequest } from "../providers/providerParameters.js";
 import { globalSettings } from '../server.js';
-import SnippetsManager from "../suggestions/snippets/snippetsManager.js";
+import { getAntlersComponentSuggestions } from '../suggestions/antlersComponentSuggestions.js';
 import { SuggestionManager } from "../suggestions/suggestionManager.js";
 
 interface ICompletionDetail {
@@ -42,7 +42,13 @@ export function handleOnCompletion(_textDocumentPosition: TextDocumentPositionPa
         }
     }
 
-    let suggestions = SuggestionManager.getSuggestions(suggestionRequest);
+    const componentSuggestions = getAntlersComponentSuggestions(
+        suggestionRequest.antlersDocument.getOriginalContent(),
+        suggestionRequest.position,
+        suggestionRequest.project
+    );
+
+    let suggestions = componentSuggestions ?? SuggestionManager.getSuggestions(suggestionRequest);
 
     const returnedItems: string[] = [];
 

--- a/server/src/suggestions/antlersComponentSuggestions.ts
+++ b/server/src/suggestions/antlersComponentSuggestions.ts
@@ -1,0 +1,126 @@
+import {
+    CompletionItem,
+    CompletionItemKind,
+    Position,
+    TextEdit,
+} from 'vscode-languageserver-protocol';
+import TagManager from '../antlers/tagManagerInstance.js';
+import { IProjectDetailsProvider } from '../projects/projectDetailsProvider.js';
+
+interface IComponentPrefix {
+    fragment: string;
+    isClosing: boolean;
+    replaceFrom: number;
+}
+
+interface IComponentCandidate {
+    documentation: string;
+    label: string;
+}
+
+function getLineAt(content: string, line: number): string | null {
+    const lines = content.split(/\r?\n/);
+
+    if (line < 0 || line >= lines.length) {
+        return null;
+    }
+
+    return lines[line];
+}
+
+function getComponentPrefix(content: string, position: Position): IComponentPrefix | null {
+    const line = getLineAt(content, position.line);
+
+    if (line == null || position.character < 0 || position.character > line.length) {
+        return null;
+    }
+
+    const lineBeforeCaret = line.slice(0, position.character),
+        match = lineBeforeCaret.match(/<(\/?)(?:(?:s|statamic)(?:-|:))([a-zA-Z0-9_:-]*)$/i);
+
+    if (match == null) {
+        return null;
+    }
+
+    const fragment = match[2] ?? '';
+
+    return {
+        fragment,
+        isClosing: match[1] == '/',
+        replaceFrom: position.character - fragment.length,
+    };
+}
+
+function addDynamicCandidates(
+    candidates: Map<string, IComponentCandidate>,
+    project: IProjectDetailsProvider
+) {
+    const addNames = (tag: string, names: string[]) => {
+        names.forEach((name) => {
+            const label = `${tag}:${name}`;
+
+            candidates.set(label, { label, documentation: '' });
+        });
+    };
+
+    addNames('collection', project.getUniqueCollectionNames());
+    addNames('form', project.getUniqueFormNames());
+    addNames('get_site', project.getSiteNames());
+    addNames('nav', project.getUniqueNavigationMenuNames());
+    addNames('structure', project.getUniqueNavigationMenuNames());
+    addNames('partial', project.getUniquePartialNames());
+    addNames('taxonomy', project.getUniqueTaxonomyNames());
+    addNames('oauth', project.getOAuthProviders());
+
+    project.getCustomAntlersTags().forEach((tag) => {
+        candidates.set(tag.tagName, { label: tag.tagName, documentation: '' });
+    });
+}
+
+function canCloseCandidate(label: string, project: IProjectDetailsProvider): boolean {
+    const tag = TagManager.instance?.findTag(label) ?? project.getCustomAntlersTags().find((candidate) => (
+        candidate.tagName == label || label.startsWith(`${candidate.tagName}:`)
+    ));
+
+    return tag?.requiresClose == true || tag?.allowsContentClose == true;
+}
+
+export function getAntlersComponentSuggestions(
+    content: string,
+    position: Position,
+    project: IProjectDetailsProvider
+): CompletionItem[] | null {
+    const prefix = getComponentPrefix(content, position);
+
+    if (prefix == null) {
+        return null;
+    }
+
+    const candidates = new Map<string, IComponentCandidate>();
+
+    TagManager.instance?.getVisibleTagsWithDocumentation().forEach((tag) => {
+        candidates.set(tag.label, { label: tag.label, documentation: tag.documentation });
+    });
+
+    addDynamicCandidates(candidates, project);
+
+    const normalizedFragment = prefix.fragment.toLowerCase(),
+        range = {
+            start: Position.create(position.line, prefix.replaceFrom),
+            end: position,
+        };
+
+    return [...candidates.values()]
+        .filter((candidate) => candidate.label.toLowerCase().startsWith(normalizedFragment))
+        .filter((candidate) => prefix.isClosing == false || canCloseCandidate(candidate.label, project))
+        .sort((left, right) => left.label.localeCompare(right.label))
+        .map((candidate): CompletionItem => ({
+            label: candidate.label,
+            kind: CompletionItemKind.Function,
+            documentation: candidate.documentation.length > 0 ? {
+                kind: 'markdown',
+                value: candidate.documentation,
+            } : undefined,
+            textEdit: TextEdit.replace(range, candidate.label),
+        }));
+}

--- a/server/src/suggestions/antlersComponentSuggestions.ts
+++ b/server/src/suggestions/antlersComponentSuggestions.ts
@@ -1,16 +1,27 @@
 import {
     CompletionItem,
     CompletionItemKind,
+    InsertReplaceEdit,
     Position,
+    Range,
     TextEdit,
 } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import TagManager from '../antlers/tagManagerInstance.js';
+import { Scope } from '../antlers/scope/scope.js';
 import { IProjectDetailsProvider } from '../projects/projectDetailsProvider.js';
+import { makeProviderRequestForDocument } from '../providers/providerParameters.js';
+import { AntlersDocument } from '../runtime/document/antlersDocument.js';
+import { ISuggestionRequest } from './suggestionRequest.js';
+import { SuggestionManager } from './suggestionManager.js';
 
-interface IComponentPrefix {
+interface IComponentContext {
+    bodyStart: number;
     fragment: string;
     isClosing: boolean;
-    replaceFrom: number;
+    isName: boolean;
+    replaceStart: number;
+    tagEnd: number | null;
 }
 
 interface IComponentCandidate {
@@ -18,36 +29,110 @@ interface IComponentCandidate {
     label: string;
 }
 
-function getLineAt(content: string, line: number): string | null {
-    const lines = content.split(/\r?\n/);
+function isEscaped(content: string, offset: number): boolean {
+    let slashCount = 0;
 
-    if (line < 0 || line >= lines.length) {
-        return null;
+    for (let index = offset - 1; index >= 0 && content[index] == '\\'; index--) {
+        slashCount++;
     }
 
-    return lines[line];
+    return slashCount % 2 == 1;
 }
 
-function getComponentPrefix(content: string, position: Position): IComponentPrefix | null {
-    const line = getLineAt(content, position.line);
+function findTagEnd(content: string, tagStart: number): number | null {
+    let quote: string | null = null;
 
-    if (line == null || position.character < 0 || position.character > line.length) {
+    for (let index = tagStart + 1; index < content.length; index++) {
+        const char = content[index];
+
+        if (quote != null) {
+            if (char == quote && !isEscaped(content, index)) {
+                quote = null;
+            }
+
+            continue;
+        }
+
+        if (char == '"' || char == "'") {
+            quote = char;
+        } else if (char == '>') {
+            return index;
+        }
+    }
+
+    return null;
+}
+
+function getComponentContext(
+    content: string,
+    position: Position,
+    document: TextDocument
+): IComponentContext | null {
+    const caretOffset = document.offsetAt(position);
+
+    const resolvedPosition = document.positionAt(caretOffset);
+
+    if (caretOffset < 0 ||
+        resolvedPosition.line != position.line ||
+        resolvedPosition.character != position.character) {
         return null;
     }
 
-    const lineBeforeCaret = line.slice(0, position.character),
-        match = lineBeforeCaret.match(/<(\/?)(?:(?:s|statamic)(?:-|:))([a-zA-Z0-9_:-]*)$/i);
+    let quote: string | null = null,
+        tagStart: number | null = null;
 
-    if (match == null) {
+    for (let index = 0; index < caretOffset; index++) {
+        const char = content[index];
+
+        if (tagStart == null) {
+            if (char == '<') {
+                tagStart = index;
+            }
+
+            continue;
+        }
+
+        if (quote != null) {
+            if (char == quote && !isEscaped(content, index)) {
+                quote = null;
+            }
+
+            continue;
+        }
+
+        if (char == '"' || char == "'") {
+            quote = char;
+        } else if (char == '>') {
+            tagStart = null;
+        } else if (char == '<') {
+            tagStart = index;
+        }
+    }
+
+    if (tagStart == null) {
         return null;
     }
 
-    const fragment = match[2] ?? '';
+    const tagBeforeCaret = content.slice(tagStart, caretOffset),
+        match = tagBeforeCaret.match(/^<(\/?)((?:s|statamic))([-:])([a-zA-Z0-9_:-]*)([\s\S]*)$/i);
+
+    if (match == null || (match[5]?.length ?? 0) > 0 && !/^\s/.test(match[5] ?? '')) {
+        return null;
+    }
+
+    const brand = match[2] ?? '',
+        separator = match[3] ?? '',
+        fragment = match[4] ?? '',
+        isClosing = match[1] == '/',
+        bodyStart = tagStart + 1 + (isClosing ? 1 : 0) + brand.length + separator.length;
 
     return {
+        bodyStart,
         fragment,
-        isClosing: match[1] == '/',
-        replaceFrom: position.character - fragment.length,
+        isClosing,
+        isName: (match[5]?.length ?? 0) == 0,
+        replaceStart: caretOffset - fragment.length,
+        tagEnd: findTagEnd(content, tagStart),
     };
 }
 
@@ -85,17 +170,11 @@ function canCloseCandidate(label: string, project: IProjectDetailsProvider): boo
     return tag?.requiresClose == true || tag?.allowsContentClose == true;
 }
 
-export function getAntlersComponentSuggestions(
-    content: string,
-    position: Position,
+function getNameSuggestions(
+    context: IComponentContext,
+    document: TextDocument,
     project: IProjectDetailsProvider
-): CompletionItem[] | null {
-    const prefix = getComponentPrefix(content, position);
-
-    if (prefix == null) {
-        return null;
-    }
-
+): CompletionItem[] {
     const candidates = new Map<string, IComponentCandidate>();
 
     TagManager.instance?.getVisibleTagsWithDocumentation().forEach((tag) => {
@@ -104,15 +183,15 @@ export function getAntlersComponentSuggestions(
 
     addDynamicCandidates(candidates, project);
 
-    const normalizedFragment = prefix.fragment.toLowerCase(),
+    const normalizedFragment = context.fragment.toLowerCase(),
         range = {
-            start: Position.create(position.line, prefix.replaceFrom),
-            end: position,
+            start: document.positionAt(context.replaceStart),
+            end: document.positionAt(context.replaceStart + context.fragment.length),
         };
 
     return [...candidates.values()]
         .filter((candidate) => candidate.label.toLowerCase().startsWith(normalizedFragment))
-        .filter((candidate) => prefix.isClosing == false || canCloseCandidate(candidate.label, project))
+        .filter((candidate) => context.isClosing == false || canCloseCandidate(candidate.label, project))
         .sort((left, right) => left.label.localeCompare(right.label))
         .map((candidate): CompletionItem => ({
             label: candidate.label,
@@ -123,4 +202,173 @@ export function getAntlersComponentSuggestions(
             } : undefined,
             textEdit: TextEdit.replace(range, candidate.label),
         }));
+}
+
+function getUnclosedQuote(content: string): string | null {
+    let quote: string | null = null;
+
+    for (let index = 0; index < content.length; index++) {
+        const char = content[index];
+
+        if (quote != null) {
+            if (char == quote && !isEscaped(content, index)) {
+                quote = null;
+            }
+        } else if (char == '"' || char == "'") {
+            quote = char;
+        }
+    }
+
+    return quote;
+}
+
+function mapRange(
+    range: Range,
+    syntheticDocument: TextDocument,
+    sourceDocument: TextDocument,
+    bodyStart: number
+): Range {
+    const mapPosition = (position: Position): Position => {
+        const syntheticOffset = syntheticDocument.offsetAt(position),
+            bodyOffset = Math.max(0, syntheticOffset - 3);
+
+        return sourceDocument.positionAt(bodyStart + bodyOffset);
+    };
+
+    return {
+        start: mapPosition(range.start),
+        end: mapPosition(range.end),
+    };
+}
+
+function mapCompletionItem(
+    item: CompletionItem,
+    syntheticDocument: TextDocument,
+    sourceDocument: TextDocument,
+    bodyStart: number
+): CompletionItem {
+    const mappedItem: CompletionItem = { ...item };
+
+    if (item.textEdit != null) {
+        if (TextEdit.is(item.textEdit)) {
+            mappedItem.textEdit = {
+                ...item.textEdit,
+                range: mapRange(item.textEdit.range, syntheticDocument, sourceDocument, bodyStart),
+            };
+        } else {
+            const edit = item.textEdit as InsertReplaceEdit;
+
+            mappedItem.textEdit = {
+                ...edit,
+                insert: mapRange(edit.insert, syntheticDocument, sourceDocument, bodyStart),
+                replace: mapRange(edit.replace, syntheticDocument, sourceDocument, bodyStart),
+            };
+        }
+    }
+
+    if (item.additionalTextEdits != null) {
+        mappedItem.additionalTextEdits = item.additionalTextEdits.map((edit) => ({
+            ...edit,
+            range: mapRange(edit.range, syntheticDocument, sourceDocument, bodyStart),
+        }));
+    }
+
+    return mappedItem;
+}
+
+function getAttributeSuggestions(
+    content: string,
+    position: Position,
+    context: IComponentContext,
+    sourceDocument: TextDocument,
+    project: IProjectDetailsProvider,
+    sourceRequest?: ISuggestionRequest
+): CompletionItem[] {
+    const caretOffset = sourceDocument.offsetAt(position),
+        bodyEnd = context.tagEnd ?? caretOffset,
+        caretInBody = caretOffset - context.bodyStart;
+    let body = content.slice(context.bodyStart, bodyEnd);
+
+    const selfClosingSlash = body.match(/\s+\/\s*$/);
+
+    if (selfClosingSlash != null && selfClosingSlash.index != null && selfClosingSlash.index >= caretInBody) {
+        body = body.slice(0, selfClosingSlash.index);
+    }
+
+    if (context.tagEnd == null) {
+        const unclosedQuote = getUnclosedQuote(body);
+
+        if (unclosedQuote != null) {
+            body += unclosedQuote;
+        }
+    }
+
+    const syntheticContent = `{{ ${body} }}\n`,
+        syntheticDocument = TextDocument.create('inmemory://antlers-component', 'antlers', 1, syntheticContent),
+        syntheticPosition = syntheticDocument.positionAt(3 + caretInBody),
+        antlersDocument = AntlersDocument.fromText(syntheticContent),
+        sourceNodes = sourceRequest?.nodesInScope ?? [];
+    let sourceScope = sourceRequest?.currentNode?.currentScope ?? null;
+
+    for (let index = sourceNodes.length - 1; index >= 0 && sourceScope == null; index--) {
+        sourceScope = sourceNodes[index].currentScope;
+    }
+
+    const activeScope = sourceScope ?? new Scope(project);
+
+    antlersDocument.documentUri = sourceRequest?.document ?? syntheticDocument.uri;
+    antlersDocument.getAllAntlersNodes().forEach((node) => {
+        node.currentScope = activeScope;
+    });
+
+    const syntheticRequest = makeProviderRequestForDocument(
+        syntheticPosition,
+        antlersDocument.documentUri,
+        antlersDocument,
+        project,
+        sourceRequest?.showGeneralSnippets ?? true
+    );
+
+    if (syntheticRequest.context?.parameterContext == null) {
+        const leftFragment = body.slice(0, caretInBody).match(/([a-zA-Z0-9_:-]+)$/)?.[1] ?? '';
+
+        syntheticRequest.leftWord = leftFragment;
+        syntheticRequest.originalLeftWord = leftFragment;
+    }
+
+    return SuggestionManager.getSuggestions(syntheticRequest).map((item) => (
+        mapCompletionItem(item, syntheticDocument, sourceDocument, context.bodyStart)
+    ));
+}
+
+export function getAntlersComponentSuggestions(
+    content: string,
+    position: Position,
+    project: IProjectDetailsProvider,
+    sourceRequest?: ISuggestionRequest
+): CompletionItem[] | null {
+    const sourceDocument = TextDocument.create(
+            sourceRequest?.document ?? 'inmemory://antlers-component-source',
+            'html',
+            1,
+            content
+        ),
+        context = getComponentContext(content, position, sourceDocument);
+
+    if (context == null) {
+        return null;
+    }
+
+    if (context.isName || context.isClosing) {
+        return getNameSuggestions(context, sourceDocument, project);
+    }
+
+    return getAttributeSuggestions(
+        content,
+        position,
+        context,
+        sourceDocument,
+        project,
+        sourceRequest
+    );
 }

--- a/server/src/suggestions/antlersDirectiveSuggestions.ts
+++ b/server/src/suggestions/antlersDirectiveSuggestions.ts
@@ -1,0 +1,75 @@
+import {
+    CompletionItem,
+    CompletionItemKind,
+    Position,
+    TextEdit,
+} from 'vscode-languageserver-protocol';
+
+interface IDirective {
+    description: string;
+    name: string;
+}
+
+const directives: IDirective[] = [
+    {
+        name: 'props',
+        description: 'Declares the properties accepted by an Antlers component. This directive requires arguments.',
+    },
+    {
+        name: 'aware',
+        description: 'Declares values inherited from a parent Antlers component. This directive requires arguments.',
+    },
+    {
+        name: 'cascade',
+        description: 'Makes values available to nested Antlers scopes. Arguments are optional.',
+    },
+];
+
+function getLineAt(content: string, line: number): string | null {
+    const lines = content.split(/\r?\n/);
+
+    if (line < 0 || line >= lines.length) {
+        return null;
+    }
+
+    return lines[line];
+}
+
+export function getAntlersDirectiveSuggestions(
+    content: string,
+    position: Position
+): CompletionItem[] | null {
+    const line = getLineAt(content, position.line);
+
+    if (line == null || position.character < 0 || position.character > line.length) {
+        return null;
+    }
+
+    const lineBeforeCaret = line.slice(0, position.character),
+        match = lineBeforeCaret.match(/(^|[^a-zA-Z0-9_@])@([a-zA-Z_]*)$/);
+
+    if (match == null) {
+        return null;
+    }
+
+    const fragment = match[2] ?? '',
+        normalizedFragment = fragment.toLowerCase(),
+        replaceFrom = position.character - fragment.length - 1,
+        range = {
+            start: Position.create(position.line, replaceFrom),
+            end: position,
+        };
+
+    return directives
+        .filter((directive) => directive.name.startsWith(normalizedFragment))
+        .map((directive): CompletionItem => ({
+            label: `@${directive.name}`,
+            kind: CompletionItemKind.Keyword,
+            detail: 'Antlers directive',
+            documentation: {
+                kind: 'markdown',
+                value: directive.description,
+            },
+            textEdit: TextEdit.replace(range, `@${directive.name}`),
+        }));
+}

--- a/server/src/test/antlers_component_suggestions.test.ts
+++ b/server/src/test/antlers_component_suggestions.test.ts
@@ -1,0 +1,63 @@
+import assert from 'assert';
+import { Position, TextEdit } from 'vscode-languageserver-protocol';
+import { IProjectDetailsProvider } from '../projects/projectDetailsProvider.js';
+import { getAntlersComponentSuggestions } from '../suggestions/antlersComponentSuggestions.js';
+
+function makeProject(): IProjectDetailsProvider {
+    return {
+        getCustomAntlersTags: () => [],
+        getOAuthProviders: () => ['github'],
+        getSiteNames: () => ['english'],
+        getUniqueCollectionNames: () => ['articles', 'news'],
+        getUniqueFormNames: () => ['contact'],
+        getUniqueNavigationMenuNames: () => ['main'],
+        getUniquePartialNames: () => ['cards/card'],
+        getUniqueTaxonomyNames: () => ['topics'],
+    } as unknown as IProjectDetailsProvider;
+}
+
+function suggestionsFor(source: string) {
+    return getAntlersComponentSuggestions(
+        source,
+        Position.create(0, source.length),
+        makeProject()
+    );
+}
+
+suite('Antlers Component Suggestions', () => {
+    test('it completes dynamic collection components', () => {
+        [
+            '<s-collection:',
+            '<s:collection:',
+            '<statamic-collection:',
+            '<statamic:collection:',
+        ].forEach((source) => {
+            const suggestions = suggestionsFor(source) ?? [];
+
+            assert.strictEqual(suggestions.some((item) => item.label == 'collection:articles'), true);
+            assert.strictEqual(suggestions.some((item) => item.label == 'collection:news'), true);
+        });
+    });
+
+    test('it replaces only the component tag fragment', () => {
+        const source = '    <s-collection:',
+            suggestion = (suggestionsFor(source) ?? []).find((item) => item.label == 'collection:articles'),
+            textEdit = suggestion?.textEdit as TextEdit;
+
+        assert.strictEqual(textEdit.newText, 'collection:articles');
+        assert.strictEqual(textEdit.range.start.character, source.indexOf('collection:'));
+        assert.strictEqual(textEdit.range.end.character, source.length);
+    });
+
+    test('it limits closing suggestions to pair-capable tags', () => {
+        const collectionSuggestions = suggestionsFor('</s-collection:') ?? [],
+            viteSuggestions = suggestionsFor('</s-vite:') ?? [];
+
+        assert.strictEqual(collectionSuggestions.some((item) => item.label == 'collection:articles'), true);
+        assert.strictEqual(viteSuggestions.some((item) => item.label == 'vite:content'), false);
+    });
+
+    test('it ignores regular HTML contexts', () => {
+        assert.strictEqual(suggestionsFor('<section class="s-collection"'), null);
+    });
+});

--- a/server/src/test/antlers_component_suggestions.test.ts
+++ b/server/src/test/antlers_component_suggestions.test.ts
@@ -1,13 +1,23 @@
 import assert from 'assert';
 import { Position, TextEdit } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Scope } from '../antlers/scope/scope.js';
 import { IProjectDetailsProvider } from '../projects/projectDetailsProvider.js';
+import { AntlersDocument } from '../runtime/document/antlersDocument.js';
 import { getAntlersComponentSuggestions } from '../suggestions/antlersComponentSuggestions.js';
+import { ISuggestionRequest } from '../suggestions/suggestionRequest.js';
 
 function makeProject(): IProjectDetailsProvider {
     return {
         getCustomAntlersTags: () => [],
+        getBlueprintFields: () => [],
+        getCollectionNames: () => ['articles', 'news'],
+        getCollectionNamesForView: () => [],
+        getCollectionQueryScopes: () => [],
         getOAuthProviders: () => ['github'],
         getSiteNames: () => ['english'],
+        hasTaxonomy: () => false,
+        hasViewCollectionInjections: () => false,
         getUniqueCollectionNames: () => ['articles', 'news'],
         getUniqueFormNames: () => ['contact'],
         getUniqueNavigationMenuNames: () => ['main'],
@@ -16,12 +26,54 @@ function makeProject(): IProjectDetailsProvider {
     } as unknown as IProjectDetailsProvider;
 }
 
-function suggestionsFor(source: string) {
+function suggestionsFor(source: string, sourceRequest?: ISuggestionRequest) {
+    const markerOffset = source.indexOf('|'),
+        cleanSource = markerOffset >= 0
+            ? source.slice(0, markerOffset) + source.slice(markerOffset + 1)
+            : source,
+        document = TextDocument.create('inmemory://component-test', 'html', 1, cleanSource),
+        position = document.positionAt(markerOffset >= 0 ? markerOffset : cleanSource.length);
+
     return getAntlersComponentSuggestions(
-        source,
-        Position.create(0, source.length),
-        makeProject()
+        cleanSource,
+        position,
+        makeProject(),
+        sourceRequest
     );
+}
+
+function makeSourceRequestWithVariables(...variables: string[]): ISuggestionRequest {
+    const project = makeProject(),
+        antlersDocument = AntlersDocument.fromText('{{ placeholder }}\n'),
+        node = antlersDocument.getAllAntlersNodes()[0],
+        scope = new Scope(project);
+
+    variables.forEach((name) => scope.addVariable({
+        name,
+        dataType: 'string',
+        sourceField: null,
+        sourceName: 'test',
+        introducedBy: null,
+    }));
+    node.currentScope = scope;
+
+    return {
+        antlersDocument,
+        currentNode: node,
+        document: 'inmemory://component-test',
+        nodesInScope: [node],
+        showGeneralSnippets: true,
+    } as ISuggestionRequest;
+}
+
+function applyEdit(source: string, edit: TextEdit): string {
+    const markerOffset = source.indexOf('|'),
+        cleanSource = source.slice(0, markerOffset) + source.slice(markerOffset + 1),
+        document = TextDocument.create('inmemory://component-test', 'html', 1, cleanSource),
+        start = document.offsetAt(edit.range.start),
+        end = document.offsetAt(edit.range.end);
+
+    return cleanSource.slice(0, start) + edit.newText + cleanSource.slice(end);
 }
 
 suite('Antlers Component Suggestions', () => {
@@ -59,5 +111,97 @@ suite('Antlers Component Suggestions', () => {
 
     test('it ignores regular HTML contexts', () => {
         assert.strictEqual(suggestionsFor('<section class="s-collection"'), null);
+    });
+
+    test('it completes component parameter names', () => {
+        [
+            '<s-collection | >',
+            '<s:collection | >',
+            '<statamic-collection | >',
+            '<statamic:collection | >',
+            '<s-collection:articles | >',
+        ].forEach((source) => {
+            const suggestions = suggestionsFor(source) ?? [];
+
+            assert.strictEqual(suggestions.some((item) => item.label == 'from'), true);
+            assert.strictEqual(suggestions.some((item) => item.label == 'limit'), true);
+        });
+    });
+
+    test('it maps partial parameter edits to the component source', () => {
+        const source = '<s-collection fr|>',
+            suggestion = (suggestionsFor(source) ?? []).find((item) => item.label == 'from'),
+            textEdit = suggestion?.textEdit as TextEdit;
+
+        assert.ok(textEdit);
+        assert.strictEqual(applyEdit(source, textEdit), '<s-collection from="$1">');
+    });
+
+    test('it completes project values for component parameters', () => {
+        const collectionSuggestions = suggestionsFor('<s-collection from="|">') ?? [],
+            formSuggestions = suggestionsFor('<s-form:create in="|">') ?? [],
+            siteSuggestions = suggestionsFor('<s-get_content locale="|">') ?? [];
+
+        assert.strictEqual(collectionSuggestions.some((item) => item.label == 'articles'), true);
+        assert.strictEqual(collectionSuggestions.some((item) => item.label == 'news'), true);
+        assert.strictEqual(formSuggestions.some((item) => item.label == 'contact'), true);
+        assert.strictEqual(siteSuggestions.some((item) => item.label == 'english'), true);
+    });
+
+    test('it maps multiline parameter edits across indentation levels', () => {
+        const source = [
+                '<div>',
+                '\t<s-collection',
+                '\t\tfr|',
+                '\t>',
+                '</div>',
+            ].join('\n'),
+            suggestion = (suggestionsFor(source) ?? []).find((item) => item.label == 'from'),
+            textEdit = suggestion?.textEdit as TextEdit;
+
+        assert.ok(textEdit);
+        assert.deepStrictEqual(textEdit.range.start, Position.create(2, 4));
+        assert.deepStrictEqual(textEdit.range.end, Position.create(2, 4));
+        assert.strictEqual(applyEdit(source, textEdit), [
+            '<div>',
+            '\t<s-collection',
+            '\t\tfrom="$1"',
+            '\t>',
+            '</div>',
+        ].join('\n'));
+    });
+
+    test('it handles unfinished quoted component values', () => {
+        const suggestions = suggestionsFor('<s-collection from="|') ?? [];
+
+        assert.strictEqual(suggestions.some((item) => item.label == 'articles'), true);
+        assert.strictEqual(suggestions.some((item) => item.label == 'news'), true);
+    });
+
+    test('it completes scope variables in bound component parameters', () => {
+        const suggestions = suggestionsFor(
+            '<s-collection :from="|">',
+            makeSourceRequestWithVariables('collection_handle')
+        ) ?? [];
+
+        assert.strictEqual(suggestions.some((item) => item.label == 'collection_handle'), true);
+    });
+
+    test('it handles quoted boundaries and self-closing components', () => {
+        const suggestions = suggestionsFor('<s-collection title="a > b" from="|" />') ?? [];
+
+        assert.strictEqual(suggestions.some((item) => item.label == 'articles'), true);
+        assert.strictEqual(suggestions.some((item) => item.label == 'news'), true);
+    });
+
+    test('it does not repeat existing component parameters', () => {
+        const suggestions = suggestionsFor('<s-collection from="articles" | >') ?? [];
+
+        assert.strictEqual(suggestions.some((item) => item.label == 'from'), false);
+        assert.strictEqual(suggestions.some((item) => item.label == 'limit'), true);
+    });
+
+    test('it ignores component-like text inside HTML attributes', () => {
+        assert.strictEqual(suggestionsFor('<section title="<s-collection |">'), null);
     });
 });

--- a/server/src/test/antlers_directive_suggestions.test.ts
+++ b/server/src/test/antlers_directive_suggestions.test.ts
@@ -1,0 +1,38 @@
+import assert from 'assert';
+import { Position, TextEdit } from 'vscode-languageserver-protocol';
+import { getAntlersDirectiveSuggestions } from '../suggestions/antlersDirectiveSuggestions.js';
+
+function suggestionsFor(source: string) {
+    return getAntlersDirectiveSuggestions(source, Position.create(0, source.length));
+}
+
+suite('Antlers Directive Suggestions', () => {
+    test('it completes supported directives', () => {
+        const suggestions = suggestionsFor('@') ?? [];
+
+        assert.deepStrictEqual(
+            suggestions.map((item) => item.label),
+            ['@props', '@aware', '@cascade']
+        );
+    });
+
+    test('it filters and replaces the complete directive', () => {
+        const source = '    @pr',
+            suggestion = (suggestionsFor(source) ?? [])[0],
+            textEdit = suggestion.textEdit as TextEdit;
+
+        assert.strictEqual(suggestion.label, '@props');
+        assert.strictEqual(textEdit.newText, '@props');
+        assert.strictEqual(textEdit.range.start.character, source.indexOf('@'));
+        assert.strictEqual(textEdit.range.end.character, source.length);
+    });
+
+    test('it ignores escaped directives and email-like text', () => {
+        assert.strictEqual(suggestionsFor('@@pr'), null);
+        assert.strictEqual(suggestionsFor('hello@pr'), null);
+    });
+
+    test('it is exclusive for unknown directive prefixes', () => {
+        assert.deepStrictEqual(suggestionsFor('@unknown'), []);
+    });
+});

--- a/server/src/test/tag_manager.test.ts
+++ b/server/src/test/tag_manager.test.ts
@@ -1,4 +1,5 @@
 import { AntlersDocument } from '../runtime/document/antlersDocument.js';
+import TagManager from '../antlers/tagManagerInstance.js';
 import { assertCount, assertFalse, assertTrue } from './testUtils/assertions.js';
 
 suite("Tag Manager Tests", () => {
@@ -9,5 +10,32 @@ suite("Tag Manager Tests", () => {
         assertTrue(nodes[0].isTagNode);
         assertFalse(nodes[1].isTagNode);
         assertTrue(nodes[2].isTagNode);
+    });
+
+    test("it recognizes modern core tag forms", () => {
+        const manager = TagManager.instance;
+
+        assertTrue(manager?.isKnownTag('dictionary:countries') ?? false);
+        assertTrue(manager?.isKnownTag('get_site:english') ?? false);
+        assertTrue(manager?.isKnownTag('can:edit_entries') ?? false);
+        assertTrue(manager?.isKnownTag('user:passkey_form') ?? false);
+        assertFalse(manager?.isKnownTag('component_proxy') ?? true);
+    });
+
+    test("it reports pair requirements for explicit methods", () => {
+        const manager = TagManager.instance;
+
+        assertTrue(manager?.findTag('form:fields')?.requiresClose ?? false);
+        assertTrue(manager?.findTag('glide:generate')?.requiresClose ?? false);
+        assertFalse(manager?.findTag('glide:data_uri')?.requiresClose ?? true);
+        assertFalse(manager?.findTag('vite:content')?.requiresClose ?? true);
+    });
+
+    test("it offers registered user methods", () => {
+        const methods = TagManager.instance?.getPossibleTagMethods('user') ?? [];
+
+        assertTrue(methods.includes('login_form'));
+        assertTrue(methods.includes('passkey_form'));
+        assertTrue(methods.includes('two_factor_setup_form'));
     });
 });


### PR DESCRIPTION
## Summary
- add current public Statamic core tags and explicit methods to completions, diagnostics, scopes, and highlighting
- complete project-aware Antlers component tags for `s-`, `s:`, `statamic-`, and `statamic:` syntax
- route component parameter names, project-backed values, and bound scope variables through the normal Antlers completion engine
- support `@props`, `@aware`, and `@cascade` completions and highlighting while preserving escaped directives

## Validation
- `npm run test:server` (304 passing)
- `npm run compile`
- TextMate tokenization smoke test for component tags, directives, and escaped directives

Tests are focused behavioral coverage; this does not add cross-repository drift fixtures or generators.