### PR TITLE
Improve CMS syntax parity

### DIFF
--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -134,11 +134,17 @@ export class NodeBuffer {
     paramS(param: ParameterNode) {
         let bParam = ' ';
 
-        if (param.isVariableReference) {
-            bParam += ':';
+        if (param.originalName.length > 0) {
+            bParam += param.originalName;
+        } else {
+            if (param.isVariableReference) {
+                bParam += ':';
+            }
+
+            bParam += param.name;
         }
 
-        bParam += param.name + '=' + param.nameDelimiter + param.value + param.nameDelimiter;
+        bParam += '=' + param.nameDelimiter + param.value + param.nameDelimiter;
 
         this.append(bParam);
 

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -1,6 +1,6 @@
 import { formatAntlers } from '../../../test/testUtils/formatAntlers.js';
 import { replaceAllInString } from '../../../utils/strings.js';
-import { AbstractNode, AdditionOperator, AntlersNode, ArgSeparator, DivisionOperator, InlineBranchSeparator, InlineTernarySeparator, LeftAssignmentOperator, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierNameNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusOperator, MultiplicationOperator, NumberNode, PathNode, ScopeAssignmentOperator, StatementSeparatorNode, StringValueNode, SubtractionOperator, TupleListStart, VariableNode } from '../../nodes/abstractNode.js';
+import { AbstractNode, AdditionOperator, AntlersNode, ArgSeparator, DivisionOperator, FalseConstant, ImplicitArrayBegin, ImplicitArrayEnd, InlineBranchSeparator, InlineTernarySeparator, LeftAssignmentOperator, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierNameNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusOperator, MultiplicationOperator, NullConstant, NumberNode, PathNode, ScopeAssignmentOperator, StatementSeparatorNode, StringValueNode, SubtractionOperator, TrueConstant, TupleListStart, VariableNode } from '../../nodes/abstractNode.js';
 import { LanguageParser } from '../../parser/languageParser.js';
 import { NodeHelpers } from '../../utilities/nodeHelpers.js';
 import { AntlersDocument } from '../antlersDocument.js';
@@ -46,6 +46,14 @@ export class NodePrinter {
                                     if (node.next instanceof VariableNode && node.next.name == 'as') {
                                         insertNlAfter = false;
                                     }
+
+                                    if (node.next instanceof VariableNode && node.next.methodDelimiter.length > 0) {
+                                        insertNlAfter = false;
+                                    }
+
+                                    if (node.next instanceof MethodInvocationNode) {
+                                        insertNlAfter = false;
+                                    }
                                 }
                             }
 
@@ -62,6 +70,11 @@ export class NodePrinter {
                             }
                         }
                     }
+                }
+
+                if ((node.prev instanceof ImplicitArrayBegin || node.prev instanceof ImplicitArrayEnd) &&
+                    doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node)) {
+                    continue;
                 }
 
                 if (node instanceof VariableNode) {
@@ -118,10 +131,25 @@ export class NodePrinter {
                     if (node.mergeRefName != null && node.mergeRefName.trim().length > 0 && node.mergeRefName != node.name) {
                         nodeBuffer.append(node.mergeRefName.trim());
                     } else {
+                        if (node.methodDelimiter.length > 0) {
+                            nodeBuffer.append(node.methodDelimiter + node.name.trim());
+                            lastPrintedNode = node;
+                            continue;
+                        }
+
                         if (node.name == 'as') {
                             nodeBuffer.appendOS('as');
                         } else {
                             if (node.methodTarget != null) {
+                                const previousNode = i > 0 ? lexerNodes[i - 1] : null,
+                                    nextNode = i + 1 < lexerNodes.length ? lexerNodes[i + 1] : null;
+
+                                if (previousNode instanceof MethodInvocationNode || nextNode instanceof MethodInvocationNode) {
+                                    nodeBuffer.append(node.name.trim());
+                                    lastPrintedNode = node;
+                                    continue;
+                                }
+
                                 if (node.variableReference != null) {
                                     node.variableReference.pathParts.forEach((part) => {
                                         if (part instanceof PathNode) {
@@ -132,7 +160,7 @@ export class NodePrinter {
                                 }
 
                                 nodeBuffer.append(node.methodTarget.method?.name ?? '');
-
+                                lastPrintedNode = node;
                                 continue;
                             }
                             nodeBuffer.append(node.name.trim());
@@ -160,6 +188,12 @@ export class NodePrinter {
                 } else if (node instanceof ModifierSeparator) {
                     nodeBuffer.appendS('|');
                 } else if (node instanceof InlineBranchSeparator) {
+                    if (node.isTernaryBranchSeparator) {
+                        nodeBuffer.appendS(':');
+                        lastPrintedNode = node;
+                        continue;
+                    }
+
                     if (lastPrintedNode != null) {
                         if (node.startPosition?.isBefore(lastPrintedNode.endPosition)) {
                             continue;
@@ -223,7 +257,11 @@ export class NodePrinter {
 
                     nodeBuffer.append(':');
                 } else if (node instanceof ModifierValueNode) {
-                    nodeBuffer.append(node.value.trim());
+                    if (node.sourceContent.length > 0) {
+                        nodeBuffer.append(node.sourceContent.trim());
+                    } else {
+                        nodeBuffer.append(node.value.trim());
+                    }
                 } else if (node instanceof LogicGroupBegin) {
                     nodeBuffer.append('(');
                 } else if (node instanceof LogicGroupEnd) {
@@ -258,6 +296,18 @@ export class NodePrinter {
                     }
 
                     nodeBuffer.append(valueToPrint);
+                } else if (node instanceof TrueConstant || node instanceof FalseConstant || node instanceof NullConstant) {
+                    if (node.prev instanceof ImplicitArrayBegin || node.prev instanceof ArgSeparator) {
+                        nodeBuffer.append(node.content);
+                    } else {
+                        nodeBuffer.appendS(node.content);
+                    }
+                } else if (node instanceof ImplicitArrayBegin || node instanceof ImplicitArrayEnd) {
+                    if (doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node)) {
+                        continue;
+                    }
+
+                    nodeBuffer.append(node.content);
                 } else if (node instanceof LeftAssignmentOperator) {
                     nodeBuffer.appendS('=');
                 } else if (node instanceof ScopeAssignmentOperator) {
@@ -332,7 +382,7 @@ export class NodePrinter {
                         nodeBuffer.appendS(node.rawContent());
                     }
                 } else if (node instanceof MethodInvocationNode) {
-                    nodeBuffer.append('->');
+                    nodeBuffer.append(node.rawContent());
                 } else if (node instanceof LogicalAndOperator) {
                     if (lastPrintedNode != null && lastPrintedNode instanceof SubtractionOperator) {
                         const distance = NodeHelpers.distance(lastPrintedNode, node);

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -306,6 +306,10 @@ export class Transformer {
     private async printNodeAsync(node: AntlersNode, targetIndent: number | null = null): Promise<string> {
         const printNode = node.getTrueNode();
 
+        if (printNode.sourceContent.includes('@{')) {
+            return `${printNode.rawStart}${printNode.sourceContent}${printNode.rawEnd}`;
+        }
+
         if ((printNode.rawStart == '{{?' || printNode.rawStart == '{{$') && this.asyncPhpFormatter != null) {
             try {
                 const formattedPhp = await this.asyncPhpFormatter(printNode.content);
@@ -355,6 +359,10 @@ export class Transformer {
 
     private printNode(node: AntlersNode, targetIndent: number | null = null) {
         const printNode = node.getTrueNode();
+
+        if (printNode.sourceContent.includes('@{')) {
+            return `${printNode.rawStart}${printNode.sourceContent}${printNode.rawEnd}`;
+        }
 
         if ((printNode.rawStart == '{{?' || printNode.rawStart == '{{$') && this.phpFormatter != null) {
             try {

--- a/server/src/runtime/lexer/antlersLexer.ts
+++ b/server/src/runtime/lexer/antlersLexer.ts
@@ -1,7 +1,7 @@
 import { AntlersError } from '../errors/antlersError.js';
 import { AntlersErrorCodes } from '../errors/antlersErrorCodes.js';
 import { TypeLabeler } from '../errors/typeLabeler.js';
-import { AbstractNode, AdditionAssignmentOperator, AdditionOperator, AntlersNode, ArgSeparator, ConditionalVariableFallbackOperator, DivisionAssignmentOperator, DivisionOperator, EqualCompOperator, ExponentiationOperator, FalseConstant, GreaterThanCompOperator, InlineBranchSeparator, InlineTernarySeparator, LeftAssignmentOperator, LessThanCompOperator, LessThanEqualCompOperator, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicalXorOperator, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierNameNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusAssignmentOperator, ModulusOperator, MultiplicationAssignmentOperator, MultiplicationOperator, NotEqualCompOperator, NotStrictEqualCompOperator, NullCoalesceOperator, NullConstant, NumberNode, ScopeAssignmentOperator, SpaceshipCompOperator, StatementSeparatorNode, StrictEqualCompOperator, StringConcatenationOperator, StringValueNode, SubtractionAssignmentOperator, SubtractionOperator, TrueConstant, TupleListStart, VariableNode } from '../nodes/abstractNode.js';
+import { AbstractNode, AdditionAssignmentOperator, AdditionOperator, AntlersNode, ArgSeparator, ConditionalVariableFallbackOperator, DivisionAssignmentOperator, DivisionOperator, EqualCompOperator, ExponentiationOperator, FalseConstant, GreaterThanCompOperator, ImplicitArrayBegin, ImplicitArrayEnd, InlineBranchSeparator, InlineTernarySeparator, LeftAssignmentOperator, LessThanCompOperator, LessThanEqualCompOperator, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicalXorOperator, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierNameNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusAssignmentOperator, ModulusOperator, MultiplicationAssignmentOperator, MultiplicationOperator, NotEqualCompOperator, NotStrictEqualCompOperator, NullCoalesceOperator, NullConstant, NumberNode, ScopeAssignmentOperator, SpaceshipCompOperator, StatementSeparatorNode, StrictEqualCompOperator, StringConcatenationOperator, StringValueNode, SubtractionAssignmentOperator, SubtractionOperator, TrueConstant, TupleListStart, VariableNode } from '../nodes/abstractNode.js';
 import { DocumentParser } from '../parser/documentParser.js';
 import { LanguageKeywords } from '../parser/languageKeywords.js';
 import { StringUtilities } from '../utilities/stringUtilities.js';
@@ -74,19 +74,15 @@ export class AntlersLexer {
         }
 
         if (this.isParsingString == false && char == ']') {
-            return true;
+            return false;
         }
 
         if (this.isParsingString == false && char == ')') {
             return false;
         }
 
-        if ((char == '[' || char == ']') && char == this.cur) {
-            return true;
-        }
-
-        if ((char == '_' || char == '.' || char == '[' || char == ']') &&
-            (!(this.currentContent.length > 0) || StringUtilities.ctypeAlpha(this.cur) || StringUtilities.ctypeDigit(this.cur))) {
+        if ((char == '_' || char == '.') &&
+            (this.currentContent.length > 0 || StringUtilities.ctypeAlpha(this.cur))) {
             return true;
         }
 
@@ -338,6 +334,12 @@ export class AntlersLexer {
                         modifierValueNode.value = parsedValue;
                         modifierValueNode.startPosition = node._lexerRelativeOffset(stringStartedOn ?? 0);
                         modifierValueNode.endPosition = node._lexerRelativeOffset(this.currentIndex);
+                        if (this.referenceParser != null) {
+                            modifierValueNode.sourceContent = this.referenceParser.getText(
+                                modifierValueNode.startPosition.index,
+                                modifierValueNode.endPosition.index + 1
+                            );
+                        }
                         modifierValueNode.parent = this.activeNode;
 
                         this.runtimeNodes.push(modifierValueNode);
@@ -1183,6 +1185,32 @@ export class AntlersLexer {
                     this.runtimeNodes.push(branchSeparator);
                     this.lastNode = branchSeparator;
                     this.isParsingModifierName = false;
+                    continue;
+                }
+
+                if (this.cur == DocumentParser.LeftBracket) {
+                    const implicitArrayBegin = new ImplicitArrayBegin();
+                    implicitArrayBegin.isVirtual = false;
+                    implicitArrayBegin.content = DocumentParser.LeftBracket;
+                    implicitArrayBegin.startPosition = node._lexerRelativeOffset(this.currentIndex);
+                    implicitArrayBegin.endPosition = node._lexerRelativeOffset(this.currentIndex + 1);
+                    implicitArrayBegin.parent = this.activeNode;
+
+                    this.runtimeNodes.push(implicitArrayBegin);
+                    this.lastNode = implicitArrayBegin;
+                    continue;
+                }
+
+                if (this.cur == DocumentParser.RightBracket) {
+                    const implicitArrayEnd = new ImplicitArrayEnd();
+                    implicitArrayEnd.isVirtual = false;
+                    implicitArrayEnd.content = DocumentParser.RightBracket;
+                    implicitArrayEnd.startPosition = node._lexerRelativeOffset(this.currentIndex);
+                    implicitArrayEnd.endPosition = node._lexerRelativeOffset(this.currentIndex + 1);
+                    implicitArrayEnd.parent = this.activeNode;
+
+                    this.runtimeNodes.push(implicitArrayEnd);
+                    this.lastNode = implicitArrayEnd;
                     continue;
                 }
             }

--- a/server/src/runtime/lexer/antlersLexer.ts
+++ b/server/src/runtime/lexer/antlersLexer.ts
@@ -427,6 +427,7 @@ export class AntlersLexer {
                     }
 
                     const parsedValue = this.currentContent.join('').trim(),
+                        lowerParsedValue = parsedValue.toLowerCase(),
                         valueLen = parsedValue.length,
                         valueStartIndex = this.currentIndex - valueLen,
                         startPosition = node._lexerRelativeOffset(valueStartIndex),
@@ -436,7 +437,7 @@ export class AntlersLexer {
                     this.rawContent = [];
 
                     // Check against internal keywords.
-                    if (parsedValue == LanguageKeywords.LogicalAnd) {
+                    if (lowerParsedValue == LanguageKeywords.LogicalAnd) {
                         const logicalAnd = new LogicalAndOperator();
                         logicalAnd.isVirtual = false;
                         logicalAnd.content = LanguageKeywords.LogicalAnd;
@@ -447,7 +448,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(logicalAnd);
                         this.lastNode = logicalAnd;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.LogicalOr) {
+                    } else if (lowerParsedValue == LanguageKeywords.LogicalOr) {
                         const logicalOr = new LogicalOrOperator();
                         logicalOr.isVirtual = false;
                         logicalOr.content = LanguageKeywords.LogicalOr;
@@ -458,7 +459,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(logicalOr);
                         this.lastNode = logicalOr;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.LogicalXor) {
+                    } else if (lowerParsedValue == LanguageKeywords.LogicalXor) {
                         const logicalXor = new LogicalXorOperator();
                         logicalXor.isVirtual = false;
                         logicalXor.content = LanguageKeywords.LogicalXor;
@@ -469,7 +470,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(logicalXor);
                         this.lastNode = logicalXor;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.ConstNull) {
+                    } else if (lowerParsedValue == LanguageKeywords.ConstNull) {
                         const constNull = new NullConstant();
                         constNull.isVirtual = false;
                         constNull.content = LanguageKeywords.ConstNull;
@@ -480,7 +481,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(constNull);
                         this.lastNode = constNull;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.ConstTrue) {
+                    } else if (lowerParsedValue == LanguageKeywords.ConstTrue) {
                         const constTrue = new TrueConstant();
                         constTrue.isVirtual = false;
                         constTrue.content = LanguageKeywords.ConstTrue;
@@ -491,7 +492,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(constTrue);
                         this.lastNode = constTrue;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.ConstFalse) {
+                    } else if (lowerParsedValue == LanguageKeywords.ConstFalse) {
                         const constFalse = new FalseConstant();
                         constFalse.isVirtual = false;
                         constFalse.content = LanguageKeywords.ConstFalse;
@@ -502,7 +503,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(constFalse);
                         this.lastNode = constFalse;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.LogicalNot) {
+                    } else if (lowerParsedValue == LanguageKeywords.LogicalNot) {
                         const logicNegation = new LogicalNegationOperator();
                         logicNegation.isVirtual = false;
                         logicNegation.content = LanguageKeywords.LogicalNot;
@@ -513,7 +514,7 @@ export class AntlersLexer {
                         this.runtimeNodes.push(logicNegation);
                         this.lastNode = logicNegation;
                         continue;
-                    } else if (parsedValue == LanguageKeywords.ArrList && this.next == DocumentParser.LeftParen) {
+                    } else if (lowerParsedValue == LanguageKeywords.ArrList && this.next == DocumentParser.LeftParen) {
                         const tupleListStart = new TupleListStart();
                         tupleListStart.isVirtual = false;
                         tupleListStart.content = LanguageKeywords.ArrList;

--- a/server/src/runtime/nodes/abstractNode.ts
+++ b/server/src/runtime/nodes/abstractNode.ts
@@ -926,6 +926,7 @@ export class ParameterNode extends AbstractNode {
     public isModifierParameter = false;
     public nameDelimiter:string|null = '"';
     public isVariableReference = false;
+    public originalName = "";
     public name = "";
     public value = "";
 

--- a/server/src/runtime/nodes/abstractNode.ts
+++ b/server/src/runtime/nodes/abstractNode.ts
@@ -1110,7 +1110,7 @@ export class DirectionGroup extends AbstractNode {
 }
 
 export class InlineBranchSeparator extends AbstractNode {
-
+    public isTernaryBranchSeparator = false;
 }
 export class ModifierSeparator extends AbstractNode {
 
@@ -1183,6 +1183,8 @@ export class ConditionalFallbackGroup extends AbstractNode {
 export class ArrayNode extends AbstractNode {
     public nodes: (NameValueNode | ArrayNode)[] = [];
 }
+export class ImplicitArrayBegin extends AbstractNode { }
+export class ImplicitArrayEnd extends AbstractNode { }
 export class TernaryCondition extends AbstractNode {
     public head: AbstractNode | null = null;
     public truthBranch: AbstractNode | null = null;
@@ -1292,6 +1294,7 @@ export class StringValueNode extends AbstractNode {
 export class VariableNode extends AbstractNode {
     public name = '';
     public mergeRefName = '';
+    public methodDelimiter = '';
     public variableReference: VariableReference | null = null;
     public interpolationNodes: AbstractNode[] = [];
     public isInterpolationReference = false;

--- a/server/src/runtime/parser/antlersNodeParser.ts
+++ b/server/src/runtime/parser/antlersNodeParser.ts
@@ -180,7 +180,7 @@ export class AntlersNodeParser {
             node.resetContentCache();
         }
 
-        if (name.startsWith('[') == false) {
+        if (name.startsWith('[') == false && name.includes('(') == false) {
             node.pathReference = this.pathParser.parse(name);
         }
         node.mergeErrors(this.pathParser.getAntlersErrors());

--- a/server/src/runtime/parser/antlersNodeParser.ts
+++ b/server/src/runtime/parser/antlersNodeParser.ts
@@ -543,18 +543,25 @@ export class AntlersNodeParser {
 
                 const parameterNode = new ParameterNode();
 
+                parameterNode.originalName = name;
+
                 if (name.startsWith(DocumentParser.Punctuation_Colon)) {
                     parameterNode.isVariableReference = true;
+                    name = name.substr(1);
+
+                    if (StringUtilities.isNumeric(content)) {
+                        parameterNode.isVariableReference = false;
+                    }
+                }
+
+                if (name.startsWith(DocumentParser.String_EscapeCharacter)) {
+                    parameterNode.containsEscapedContent = true;
                     name = name.substr(1);
                 }
 
                 parameterNode.nameDelimiter = nameDelimiter;
                 parameterNode.name = name;
                 parameterNode.value = content;
-
-                if (name.startsWith(DocumentParser.String_EscapeCharacter)) {
-                    parameterNode.containsEscapedContent = true;
-                }
 
                 if (parameterNode.nameDelimiter == null) {
                     parameterNode.hasValidValueDelimiter = false;

--- a/server/src/runtime/parser/antlersNodeParser.ts
+++ b/server/src/runtime/parser/antlersNodeParser.ts
@@ -47,12 +47,12 @@ export class AntlersNodeParser {
         this.activeNode = node;
         this.reset();
 
-        if (node.content.startsWith('*subrecursive')) {
+        if (node.content.trim().startsWith('*subrecursive')) {
             let nodeContent = node.content;
 
             nodeContent = nodeContent.trim();
             nodeContent = StringUtilities.trimRight(nodeContent, '*');
-            nodeContent = nodeContent.substr(13);
+            nodeContent = nodeContent.substr(13).trim();
 
             const recursiveNode = new RecursiveNode();
             node.copyBasicDetailsTo(recursiveNode);

--- a/server/src/runtime/parser/languageKeywords.ts
+++ b/server/src/runtime/parser/languageKeywords.ts
@@ -1,3 +1,5 @@
+import { StringUtilities } from '../utilities/stringUtilities.js';
+
 export class LanguageKeywords {
     static readonly LogicalAnd = 'and';
     static readonly LogicalNot = 'not';
@@ -12,6 +14,10 @@ export class LanguageKeywords {
 
     static isLanguageLogicalKeyword(value: string) {
         if (value == this.LogicalAnd || value == this.LogicalNot || value == this.LogicalOr || value == this.LogicalXor) {
+            return true;
+        }
+
+        if (StringUtilities.ctypePunct(value.substring(0, 1))) {
             return true;
         }
 

--- a/server/src/runtime/parser/languageParser.ts
+++ b/server/src/runtime/parser/languageParser.ts
@@ -2,7 +2,7 @@ import { AntlersError } from '../errors/antlersError.js';
 import { AntlersErrorCodes } from '../errors/antlersErrorCodes.js';
 import { LineRetriever } from '../errors/lineRetriever.js';
 import { TypeLabeler } from '../errors/typeLabeler.js';
-import { AbstractNode, AdditionAssignmentOperator, AdditionOperator, AliasedScopeLogicGroup, AntlersNode, ArgSeparator, ArgumentGroup, ArrayNode, ConditionalVariableFallbackOperator, DirectionGroup, DivisionAssignmentOperator, DivisionOperator, EqualCompOperator, ExponentiationOperator, FactorialOperator, FalseConstant, GreaterThanCompOperator, GreaterThanEqualCompOperator, InlineBranchSeparator, InlineTernarySeparator, LanguageOperatorConstruct, LeftAssignmentOperator, LessThanCompOperator, LessThanEqualCompOperator, LibraryInvocationConstruct, ListValueNode, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicalXorOperator, LogicGroup, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierChainNode, ModifierNameNode, ModifierNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusAssignmentOperator, ModulusOperator, MultiplicationAssignmentOperator, MultiplicationOperator, NamedArgumentNode, NameValueNode, NotEqualCompOperator, NotStrictEqualCompOperator, NullCoalescenceGroup, NullCoalesceOperator, NullConstant, NumberNode, PathNode, ScopeAssignmentOperator, ScopedLogicGroup, SemanticGroup, SpaceshipCompOperator, StatementSeparatorNode, StaticTracedAssignment, StrictEqualCompOperator, StringConcatenationOperator, StringValueNode, SubtractionAssignmentOperator, SubtractionOperator, SwitchCase, SwitchGroup, TernaryCondition, TrueConstant, TupleList, TupleListStart, TupleScopedLogicGroup, ValueDirectionNode, VariableNode } from '../nodes/abstractNode.js';
+import { AbstractNode, AdditionAssignmentOperator, AdditionOperator, AliasedScopeLogicGroup, AntlersNode, ArgSeparator, ArgumentGroup, ArrayNode, ConditionalVariableFallbackOperator, DirectionGroup, DivisionAssignmentOperator, DivisionOperator, EqualCompOperator, ExponentiationOperator, FactorialOperator, FalseConstant, GreaterThanCompOperator, GreaterThanEqualCompOperator, ImplicitArrayBegin, ImplicitArrayEnd, InlineBranchSeparator, InlineTernarySeparator, LanguageOperatorConstruct, LeftAssignmentOperator, LessThanCompOperator, LessThanEqualCompOperator, LibraryInvocationConstruct, ListValueNode, LogicalAndOperator, LogicalNegationOperator, LogicalOrOperator, LogicalXorOperator, LogicGroup, LogicGroupBegin, LogicGroupEnd, MethodInvocationNode, ModifierChainNode, ModifierNameNode, ModifierNode, ModifierSeparator, ModifierValueNode, ModifierValueSeparator, ModulusAssignmentOperator, ModulusOperator, MultiplicationAssignmentOperator, MultiplicationOperator, NamedArgumentNode, NameValueNode, NotEqualCompOperator, NotStrictEqualCompOperator, NullCoalescenceGroup, NullCoalesceOperator, NullConstant, NumberNode, PathNode, ScopeAssignmentOperator, ScopedLogicGroup, SemanticGroup, SpaceshipCompOperator, StatementSeparatorNode, StaticTracedAssignment, StrictEqualCompOperator, StringConcatenationOperator, StringValueNode, SubtractionAssignmentOperator, SubtractionOperator, SwitchCase, SwitchGroup, TernaryCondition, TrueConstant, TupleList, TupleListStart, TupleScopedLogicGroup, ValueDirectionNode, VariableNode } from '../nodes/abstractNode.js';
 import { LibraryManager } from '../runtime/libraries/libraryManager.js';
 import { LanguageOperatorRegistry } from '../runtime/sandbox/languageOperatorRegistry.js';
 import { NodeHelpers } from '../utilities/nodeHelpers.js';
@@ -124,6 +124,7 @@ export class LanguageParser {
         this.tokens = tokens;
 
         this.tokens = this.combineVariablePaths(this.tokens);
+        this.tokens = this.rewriteImplicitArraysToKeywordForm(this.tokens);
 
         this.tokens = this.createLanguageOperators(this.tokens);
         this.tokens = this.createLogicalGroups(this.tokens);
@@ -164,6 +165,40 @@ export class LanguageParser {
         this.isRoot = isRoot;
 
         return this;
+    }
+
+    private rewriteImplicitArraysToKeywordForm(nodes: AbstractNode[]) {
+        const newNodes: AbstractNode[] = [];
+
+        nodes.forEach((node) => {
+            if (node instanceof ImplicitArrayBegin) {
+                const arrayConstruct = new LanguageOperatorConstruct();
+                arrayConstruct.startPosition = node.startPosition;
+                arrayConstruct.endPosition = node.endPosition;
+                arrayConstruct.originalAbstractNode = node;
+                arrayConstruct.content = LanguageOperatorRegistry.ARR_MAKE;
+
+                const logicGroupBegin = new LogicGroupBegin();
+                logicGroupBegin.startPosition = node.startPosition;
+                logicGroupBegin.endPosition = node.endPosition;
+                logicGroupBegin.originalAbstractNode = node;
+                logicGroupBegin.content = '(';
+
+                newNodes.push(arrayConstruct, logicGroupBegin);
+            } else if (node instanceof ImplicitArrayEnd) {
+                const logicGroupEnd = new LogicGroupEnd();
+                logicGroupEnd.startPosition = node.startPosition;
+                logicGroupEnd.endPosition = node.endPosition;
+                logicGroupEnd.originalAbstractNode = node;
+                logicGroupEnd.content = ')';
+
+                newNodes.push(logicGroupEnd);
+            } else {
+                newNodes.push(node);
+            }
+        });
+
+        return newNodes;
     }
 
     private validateNeighboringOperators(tokens: AbstractNode[]) {
@@ -357,6 +392,21 @@ export class LanguageParser {
         return variableNode;
     }
 
+    private wrapConstantInVariable(node: AbstractNode) {
+        const variableNode = new VariableNode();
+        variableNode.startPosition = node.startPosition;
+        variableNode.endPosition = node.endPosition;
+        variableNode.name = node.content;
+        variableNode.content = node.content;
+        variableNode.originalAbstractNode = node;
+        variableNode.refId = node.refId;
+        variableNode.modifierChain = node.modifierChain;
+        variableNode.index = node.index;
+        this.createdVariables.push(variableNode);
+
+        return variableNode;
+    }
+
     private wrapStringInVariable(node: StringValueNode) {
         const variableNode = new VariableNode();
         variableNode.startPosition = node.startPosition;
@@ -418,12 +468,21 @@ export class LanguageParser {
                     continue;
                 }
 
-                const left = newNodes[newNodeCount - 1];
-                let right = tokens[i + 1];
+                let left = newNodes[newNodeCount - 1],
+                    right = tokens[i + 1];
 
 
                 if (right instanceof NumberNode && NodeHelpers.distance(left, right) == 1) {
                     right = this.wrapNumberInVariable(right);
+                }
+
+                if ((right instanceof NullConstant || right instanceof TrueConstant || right instanceof FalseConstant) && NodeHelpers.distance(left, right) == 1) {
+                    right = this.wrapConstantInVariable(right);
+                }
+
+                if (left instanceof NumberNode && right instanceof VariableNode) {
+                    left = this.wrapNumberInVariable(left);
+                    newNodes[newNodeCount - 1] = left;
                 }
 
                 if (left instanceof VariableNode && right instanceof VariableNode && NodeHelpers.distance(left, right) == 1) {
@@ -483,6 +542,60 @@ export class LanguageParser {
                 } else {
                     newNodes.push(node);
                 }
+            } else if (node instanceof ImplicitArrayBegin && newNodeCount > 0) {
+                if ((i + 1) >= tokenCount) {
+                    newNodes.push(node);
+                    continue;
+                }
+
+                const left = newNodes[newNodeCount - 1],
+                    right = tokens[i + 1];
+
+                if (left instanceof VariableNode && this.canMergeIntoVariablePath(right) &&
+                    NodeHelpers.distance(left, node) <= 1 && NodeHelpers.distance(node, right) <= 1) {
+                    const mergeRefName = left.mergeRefName;
+                    newNodes.pop();
+                    NodeHelpers.mergeVarContentLeft(node.content, node, left);
+                    const rightContent = this.getMergeContent(right);
+                    NodeHelpers.mergeVarContentLeft(rightContent, right, left);
+                    left.mergeRefName = mergeRefName.length > 0 ? mergeRefName + node.content + rightContent : '';
+
+                    newNodes.push(left);
+                    this.mergedComponents.set(left, left);
+                    this.mergedComponents.set(node, left);
+                    this.mergedComponents.set(right, left);
+                    i += 1;
+                    continue;
+                }
+
+                newNodes.push(node);
+            } else if (node instanceof ImplicitArrayEnd && newNodeCount > 0) {
+                const left = newNodes[newNodeCount - 1];
+
+                if (left instanceof VariableNode && NodeHelpers.distance(left, node) <= 1 && left.name.includes('[')) {
+                    const mergeRefName = left.mergeRefName;
+                    newNodes.pop();
+                    NodeHelpers.mergeVarContentLeft(node.content, node, left);
+                    left.mergeRefName = mergeRefName.length > 0 ? mergeRefName + node.content : '';
+                    newNodes.push(left);
+                    this.mergedComponents.set(node, left);
+                    continue;
+                }
+
+                newNodes.push(node);
+            } else if (node instanceof VariableNode && newNodeCount > 0) {
+                const left = newNodes[newNodeCount - 1];
+
+                if (left instanceof VariableNode && NodeHelpers.distance(left, node) < 1) {
+                    const mergeRefName = left.mergeRefName;
+                    newNodes.pop();
+                    NodeHelpers.mergeVarContentLeft(node.name, node, left);
+                    left.mergeRefName = mergeRefName.length > 0 ? mergeRefName + node.name : '';
+                    newNodes.push(left);
+                    this.mergedComponents.set(node, left);
+                } else {
+                    newNodes.push(node);
+                }
             } else if (node instanceof SubtractionOperator && newNodeCount > 0) {
                 const left = newNodes[newNodeCount - 1],
                     right  = tokens[i + 1];
@@ -518,6 +631,56 @@ export class LanguageParser {
         });
 
         return newNodes;
+    }
+
+    private canMergeIntoVariablePath(node: AbstractNode) {
+        return node instanceof ModifierValueNode ||
+            node instanceof VariableNode ||
+            node instanceof TrueConstant ||
+            node instanceof FalseConstant ||
+            node instanceof NullConstant ||
+            node instanceof NumberNode ||
+            node instanceof StringValueNode;
+    }
+
+    private getMergeContent(node: AbstractNode) {
+        if (node instanceof ModifierValueNode) {
+            return node.value;
+        }
+
+        if (node instanceof VariableNode) {
+            return node.name;
+        }
+
+        if (node instanceof TrueConstant) {
+            return LanguageKeywords.ConstTrue;
+        }
+
+        if (node instanceof FalseConstant) {
+            return LanguageKeywords.ConstFalse;
+        }
+
+        if (node instanceof NullConstant) {
+            return LanguageKeywords.ConstNull;
+        }
+
+        if (node instanceof StringValueNode) {
+            if (node.sourceContent.length > 0) {
+                return node.sourceContent;
+            }
+
+            if (node.rawLexContent.length > 0) {
+                return node.rawLexContent;
+            }
+
+            return node.sourceTerminator + node.value + node.sourceTerminator;
+        }
+
+        if (node instanceof NumberNode) {
+            return node.rawLexContent.length > 0 ? node.rawLexContent : node.value?.toString() ?? '';
+        }
+
+        return node.innerContent();
     }
 
     private convertVarNodeToOperator(variable: VariableNode) {
@@ -850,6 +1013,7 @@ export class LanguageParser {
 
     private cleanVariableForMethodInvocation(node: VariableNode) {
         if (node.name.startsWith(':') || node.name.startsWith('.')) {
+            node.methodDelimiter = node.name.substring(0, 1);
             node.name = node.name.substr(1);
 
             if (node.variableReference != null) {
@@ -2286,6 +2450,10 @@ export class LanguageParser {
 
             if (node instanceof InlineTernarySeparator) {
                 const separator = this.seek(InlineBranchSeparator, i + 1);
+
+                if (separator.node instanceof InlineBranchSeparator) {
+                    separator.node.isTernaryBranchSeparator = true;
+                }
 
                 if (separator.node?.originalAbstractNode != null) {
                     if (separator.node.originalAbstractNode instanceof ModifierValueSeparator) {

--- a/server/src/test/basic_node.test.ts
+++ b/server/src/test/basic_node.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./testUtils/assertions.js";
 import { getParsedRuntimeNodes, parseNodes } from "./testUtils/parserUtils.js";
 import EnvironmentDetails from "../runtime/runtime/environmentDetails.js";
-import { AntlersNode, LiteralNode, SemanticGroup, VariableNode, LogicGroup, EqualCompOperator, ModifierNode, PathNode, VariableReference } from '../runtime/nodes/abstractNode.js';
+import { AntlersNode, LiteralNode, SemanticGroup, VariableNode, LogicGroup, EqualCompOperator, ModifierNode, PathNode, RecursiveNode, VariableReference } from '../runtime/nodes/abstractNode.js';
 
 suite("Basic Node Test", () => {
     test("it returns nodes", () => {
@@ -19,6 +19,15 @@ suite("Basic Node Test", () => {
         assertInstanceOf(LiteralNode, nodes[1]);
         assertInstanceOf(AntlersNode, nodes[2]);
         assertInstanceOf(LiteralNode, nodes[3]);
+    });
+
+    test("it parses indented subrecursive nodes", () => {
+        const nodes = parseNodes("{{ *subrecursive colors* }}");
+
+        assertCount(1, nodes);
+        assertInstanceOf(RecursiveNode, nodes[0]);
+        assertTrue((nodes[0] as RecursiveNode).isNestedRecursive);
+        assert.strictEqual((nodes[0] as RecursiveNode).name?.name, "colors");
     });
 
     test("it doesnt trim off content start", () => {

--- a/server/src/test/formatter_escaped.test.ts
+++ b/server/src/test/formatter_escaped.test.ts
@@ -149,4 +149,16 @@ end`;
             assert.strictEqual(formatAntlers(expected), expected);
         });
     });
+
+    test('it preserves quoted modifier escapes', () => {
+        const samples = [
+            [String.raw`{{ title | modifier:"hello \"\\ world" }}`, String.raw`{{ title | modifier:"hello \"\\ world" }}`],
+            [String.raw`{{ "\"\n\t|||||hello:::::||:||\\'\\" | remove_right: "\"\n\t|||||hello:::::||:||\\'\\" }}`, String.raw`{{ "\"\n\t|||||hello:::::||:||\\'\\" | remove_right:"\"\n\t|||||hello:::::||:||\\'\\" }}`]
+        ];
+
+        samples.forEach(([input, expected]) => {
+            assert.strictEqual(formatAntlers(input), expected);
+            assert.strictEqual(formatAntlers(expected), expected);
+        });
+    });
 });

--- a/server/src/test/formatter_escaped.test.ts
+++ b/server/src/test/formatter_escaped.test.ts
@@ -135,4 +135,18 @@ end`;
     test('it emits escaped content characters', () => {
         assert.strictEqual(formatAntlers('{{ "hello{"@@{world@@}"}" }}'), '{{ "hello{"@@{world@@}"}" }}');
     });
+
+    test('it preserves escaped brace expressions', () => {
+        const samples = [
+            ["{{ var = '@{@{@}@}'; }}{{ var }}", "{{ var = '@{@{@}@}'; }}\n{{ var }}"],
+            ["{{ starts_with('@{') }}", "{{ starts_with('@{') }}"],
+            ['{{ "hello@{" }}', '{{ "hello@{" }}'],
+            ["{{ test variable=\"{ starts_with('@{') }\" }}", "{{ test variable=\"{ starts_with('@{') }\" }}"]
+        ];
+
+        samples.forEach(([input, expected]) => {
+            assert.strictEqual(formatAntlers(input), expected);
+            assert.strictEqual(formatAntlers(expected), expected);
+        });
+    });
 });

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -87,6 +87,14 @@ suite('Formatter Operators', () => {
         assert.strictEqual(formatAntlers('{{ left   and     right }}'), '{{ left and right }}');
     });
 
+    test('it normalizes uppercase logical keywords and constants', () => {
+        const input = '{{ TrUe AND FALSE oR something }}';
+        const output = '{{ true and false \n or something }}';
+
+        assert.strictEqual(formatAntlers(input), output);
+        assert.strictEqual(formatAntlers(output), output);
+    });
+
     test('it emits symbolic and full', () => {
         assert.strictEqual(formatAntlers('{{ left   &&     right }}'), '{{ left && right }}');
     });

--- a/server/src/test/formatter_prettier_escaped.test.ts
+++ b/server/src/test/formatter_prettier_escaped.test.ts
@@ -152,4 +152,19 @@ end`;
             assert.strictEqual(twice, expected);
         }
     });
+
+    test('it preserves quoted modifier escapes', async () => {
+        const samples = [
+            [String.raw`{{ title | modifier:"hello \"\\ world" }}`, String.raw`{{ title | modifier:"hello \"\\ world" }}`],
+            [String.raw`{{ "\"\n\t|||||hello:::::||:||\\'\\" | remove_right: "\"\n\t|||||hello:::::||:||\\'\\" }}`, String.raw`{{ "\"\n\t|||||hello:::::||:||\\'\\" | remove_right:"\"\n\t|||||hello:::::||:||\\'\\" }}`]
+        ];
+
+        for (const [input, expected] of samples) {
+            const once = (await formatStringWithPrettier(input)).trim();
+            const twice = (await formatStringWithPrettier(once)).trim();
+
+            assert.strictEqual(once, expected);
+            assert.strictEqual(twice, expected);
+        }
+    });
 });

--- a/server/src/test/formatter_prettier_escaped.test.ts
+++ b/server/src/test/formatter_prettier_escaped.test.ts
@@ -135,4 +135,21 @@ end`;
     test('it emits escaped content characters', async () => {
         assert.strictEqual((await formatStringWithPrettier('{{ "hello{"@@{world@@}"}" }}')).trim(), '{{ "hello{"@@{world@@}"}" }}');
     });
+
+    test('it preserves escaped brace expressions', async () => {
+        const samples = [
+            ["{{ var = '@{@{@}@}'; }}{{ var }}", "{{ var = '@{@{@}@}'; }}\n{{ var }}"],
+            ["{{ starts_with('@{') }}", "{{ starts_with('@{') }}"],
+            ['{{ "hello@{" }}', '{{ "hello@{" }}'],
+            ["{{ test variable=\"{ starts_with('@{') }\" }}", "{{ test variable=\"{ starts_with('@{') }\" }}"]
+        ];
+
+        for (const [input, expected] of samples) {
+            const once = (await formatStringWithPrettier(input)).trim();
+            const twice = (await formatStringWithPrettier(once)).trim();
+
+            assert.strictEqual(once, expected);
+            assert.strictEqual(twice, expected);
+        }
+    });
 });

--- a/server/src/test/formatter_tags.test.ts
+++ b/server/src/test/formatter_tags.test.ts
@@ -125,6 +125,13 @@ After Partial
         assert.strictEqual(formatAntlers(template), output);
     });
 
+    test('it preserves escaped and numeric parameter names', () => {
+        const input = '{{ form \\x-data="{ open: false }" :limit="10" }}';
+
+        assert.strictEqual(formatAntlers(input), input);
+        assert.strictEqual(formatAntlers(formatAntlers(input)), input);
+    });
+
     test('it preserves subrecursive nodes', () => {
         const input = '{{ *subrecursive colors* }}';
 

--- a/server/src/test/formatter_tags.test.ts
+++ b/server/src/test/formatter_tags.test.ts
@@ -125,6 +125,13 @@ After Partial
         assert.strictEqual(formatAntlers(template), output);
     });
 
+    test('it preserves subrecursive nodes', () => {
+        const input = '{{ *subrecursive colors* }}';
+
+        assert.strictEqual(formatAntlers(input), input);
+        assert.strictEqual(formatAntlers(formatAntlers(input)), input);
+    });
+
     test('it does not remove : on simple tags', () => {
         const template = `{{ tag scope="foo" }}
         {{ foo:one }} {{ foo:two }}

--- a/server/src/test/method_syntax.test.ts
+++ b/server/src/test/method_syntax.test.ts
@@ -1,0 +1,143 @@
+import assert from 'assert';
+import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
+import { AntlersNode, ArrayNode, LogicGroup, MethodInvocationNode, SemanticGroup } from '../runtime/nodes/abstractNode.js';
+import { DocumentParser } from '../runtime/parser/documentParser.js';
+import { formatAntlers } from './testUtils/formatAntlers.js';
+
+suite('Method and Array Syntax', () => {
+    test('array arguments parse in every method style', () => {
+        const samples = [
+            "{{ instance->join(['one', 'two', ['three']]) }}",
+            "{{ instance:join(['one', 'two']) }}",
+            "{{ instance.join(['one', 'two']) }}"
+        ];
+
+        samples.forEach((sample) => {
+            const parser = parseWithoutErrors(sample);
+            const antlersNode = parser.getNodes()[0] as AntlersNode;
+            const semanticGroup = antlersNode.parsedRuntimeNodes[0] as SemanticGroup;
+            const methodGroup = semanticGroup.nodes[0] as LogicGroup;
+            const invocation = methodGroup.nodes.find((node) => node instanceof MethodInvocationNode) as MethodInvocationNode;
+
+            assert.ok(invocation instanceof MethodInvocationNode);
+            assert.ok(invocation.args?.args[0] instanceof ArrayNode);
+        });
+    });
+
+    test('array accessors remain intact', () => {
+        const samples = [
+            '{{ posts[1]title }}',
+            '{{ posts[1].title }}',
+            '{{ posts["key"] }}',
+            '{{ posts[true] }}',
+            '{{ posts[false] }}',
+            '{{ posts[null] }}',
+            '{{ view:background["default"] }}'
+        ];
+
+        samples.forEach((sample) => {
+            parseWithoutErrors(sample);
+            assertStableFormatting(sample, sample);
+        });
+    });
+
+    test('nested shorthand arrays remain compact and stable', () => {
+        const sample = "{{ values = ['a' => ['b' => [true, false, null]]] }}";
+
+        parseWithoutErrors(sample);
+        assertStableFormatting(sample, sample);
+    });
+
+    test('escaped array accessors remain intact', () => {
+        const samples = [
+            String.raw`{{ test['\\test'] }}`,
+            String.raw`{{ test['\ntest'] }}`,
+            String.raw`{{ test['\ttest'] }}`,
+            String.raw`{{ test['\rtest'] }}`,
+            String.raw`{{ test['test[\'test\']'] }}`
+        ];
+
+        samples.forEach((sample) => {
+            parseWithoutErrors(sample);
+            assertStableFormatting(sample, sample);
+        });
+    });
+
+    test('method accessors remain intact', () => {
+        const samples = [
+            '{{ $title->length() }}',
+            '{{ slot->hasActualContent()->trim() }}',
+            '{{ slot.hasActualContent() }}',
+            '{{ slot:hasActualContent() }}'
+        ];
+
+        samples.forEach((sample) => {
+            parseWithoutErrors(sample);
+            assertStableFormatting(sample, sample);
+        });
+    });
+
+    test('multiline colon method chains parse and stabilize', () => {
+        const input = `{{
+    datetime:parse("October 12, 2001"):
+            addDays(10):
+            toAtomString()
+}}`;
+        const expected = '{{ datetime:parse("October 12, 2001"):addDays(10):toAtomString() }}';
+
+        parseWithoutErrors(input);
+        assertStableFormatting(input, expected);
+    });
+
+    test('attribute method chains with arrays parse and stabilize', () => {
+        const input = `<div {{
+    attributes.merge([
+        'class' => 'hello-there!'
+    ])
+    .merge([
+        'class' => 'another-one'
+    ])
+}}>x</div>`;
+        const expected = "<div {{ attributes.merge(['class' => 'hello-there!']).merge(['class' => 'another-one']) }}>x</div>";
+
+        parseWithoutErrors(input);
+        assertStableFormatting(input, expected);
+    });
+
+    test('prettier preserves method and array syntax', async () => {
+        const samples = [
+            "{{ instance->join(['one', 'two']) }}",
+            "{{ instance:join(['one', 'two']) }}",
+            "{{ instance.join(['one', 'two']) }}",
+            '{{ slot->hasActualContent()->trim() }}'
+        ];
+
+        for (const sample of samples) {
+            const once = (await formatStringWithPrettier(sample)).trim();
+            const twice = (await formatStringWithPrettier(once)).trim();
+
+            assert.strictEqual(once, sample);
+            assert.strictEqual(twice, sample);
+        }
+    });
+});
+
+function parseWithoutErrors(input: string) {
+    const parser = new DocumentParser();
+    parser.parse(input);
+
+    assert.deepStrictEqual(
+        parser.getAntlersErrors().map((error) => `${error.errorCode}: ${error.message}`),
+        []
+    );
+
+    return parser;
+}
+
+function assertStableFormatting(input: string, expected: string) {
+    const once = formatAntlers(input);
+    const twice = formatAntlers(once);
+
+    assert.strictEqual(once, expected);
+    assert.strictEqual(twice, expected);
+}

--- a/server/src/test/modifiers.test.ts
+++ b/server/src/test/modifiers.test.ts
@@ -6,6 +6,7 @@ import {
     assertNotNull,
 } from "./testUtils/assertions.js";
 import { getParsedRuntimeNodes } from "./testUtils/parserUtils.js";
+import { DocumentParser } from '../runtime/parser/documentParser.js';
 
 suite("Node Modifiers Test", () => {
     test("it parses node modifiers", () => {
@@ -115,6 +116,13 @@ suite("Node Modifiers Test", () => {
         const modifierValue = modifierOne.valueNodes[0] as ModifierValueNode;
 
         assert.strictEqual(modifierValue.value, 'hello "\\ world');
+    });
+
+    test("shorthand modifiers stop before symbolic operators", () => {
+        const parser = new DocumentParser();
+        parser.parse('{{ url | contains:/about/news && uri !== \'/about/news\' }}');
+
+        assert.deepStrictEqual(parser.getAntlersErrors(), []);
     });
 });
 

--- a/server/src/test/node_parameters.test.ts
+++ b/server/src/test/node_parameters.test.ts
@@ -60,6 +60,29 @@ suite("Node Parameters Test", () => {
         assertTrue(param1.isVariableReference);
     });
 
+    test("escaped parameter names disable Antlers parsing", () => {
+        const nodes = parseNodes('{{ form \\x-data="{ open: false }" \\attr:x-bind="{ value }" }}');
+        const node = toAntlers(nodes[0]);
+
+        assertCount(2, node.parameters);
+        assert.strictEqual(node.parameters[0].originalName, "\\x-data");
+        assert.strictEqual(node.parameters[0].name, "x-data");
+        assertTrue(node.parameters[0].containsEscapedContent);
+        assert.strictEqual(node.parameters[1].originalName, "\\attr:x-bind");
+        assert.strictEqual(node.parameters[1].name, "attr:x-bind");
+        assertTrue(node.parameters[1].containsEscapedContent);
+    });
+
+    test("bound numeric parameters are literal values", () => {
+        const nodes = parseNodes('{{ collection :limit="10" }}');
+        const parameter = toAntlers(nodes[0]).parameters[0];
+
+        assert.strictEqual(parameter.originalName, ":limit");
+        assert.strictEqual(parameter.name, "limit");
+        assertFalse(parameter.isVariableReference);
+        assert.strictEqual(parameter.value, "10");
+    });
+
     test("equals followed by space is not a parameter", () => {
         const nodes = parseNodes(
             "{{ is_current || is_parent ?= 'font-medium text-gray-800' }}"


### PR DESCRIPTION
## Summary

- align logical keywords, recursive nodes, and escaped parameter metadata with current CMS behavior
- support shorthand arrays in method arguments and preserve array accessor boundaries
- stabilize arrow, dot, and colon method chains, including chained attribute helpers
- preserve escaped braces, quoted modifier values, and authored escape sequences

## Verification

- `npm run test:server` (303 passing)
- one-time audit of 1,232 unique Antlers snippets extracted from the CMS test suite and fixtures
- repeated Beautify and Prettier formatting coverage for the new syntax cases

No cross-repository drift fixtures or generated audit artifacts are included.