### PR TITLE
Format embedded PHP

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,9 +9,11 @@
             "version": "1.2.19",
             "license": "MIT",
             "dependencies": {
+                "@prettier/plugin-php": "^0.22",
                 "file-uri-to-path": "^2.0.0",
                 "js-beautify": "^1.13.13",
                 "js-yaml": "^4.1.0",
+                "prettier": "^3",
                 "semver": "^5.7.1",
                 "ts-debounce": "^3.0.0",
                 "ts-md5": "^1.2.9",
@@ -21,13 +23,11 @@
                 "yargs": "^17.3.1"
             },
             "devDependencies": {
-                "@prettier/plugin-php": "^0.22",
                 "@types/js-beautify": "^1.14.3",
                 "@types/js-yaml": "^4.0.5",
                 "@types/prettier": "^2.6.3",
                 "@types/semver": "^7.3.5",
                 "@typescript-eslint/parser": "^4.29.3",
-                "prettier": "^3",
                 "typescript": "^4.4.2"
             },
             "engines": {
@@ -273,7 +273,6 @@
             "version": "0.22.1",
             "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.22.1.tgz",
             "integrity": "sha512-TN7tzC2/jCM1/H/mlUjqPos8lIV+vm8Qwp83KofuZclGlG9PoUWHU7m0yqskjAoCy+R4ZCV0hxdBLPBkU69S2Q==",
-            "dev": true,
             "dependencies": {
                 "linguist-languages": "^7.27.0",
                 "mem": "^9.0.2",
@@ -1381,8 +1380,7 @@
         "node_modules/linguist-languages": {
             "version": "7.27.0",
             "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.27.0.tgz",
-            "integrity": "sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw==",
-            "dev": true
+            "integrity": "sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -1414,7 +1412,6 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
             "dependencies": {
                 "p-defer": "^1.0.0"
             },
@@ -1426,7 +1423,6 @@
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.2.tgz",
             "integrity": "sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==",
-            "dev": true,
             "dependencies": {
                 "map-age-cleaner": "^0.1.3",
                 "mimic-fn": "^4.0.0"
@@ -1464,7 +1460,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1551,7 +1546,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
             "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -1599,8 +1593,7 @@
         "node_modules/php-parser": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.5.tgz",
-            "integrity": "sha512-jEY2DcbgCm5aclzBdfW86GM6VEIWcSlhTBSHN1qhJguVePlYe28GhwS0yoeLYXpM2K8y6wzLwrbq814n2PHSoQ==",
-            "dev": true
+            "integrity": "sha512-jEY2DcbgCm5aclzBdfW86GM6VEIWcSlhTBSHN1qhJguVePlYe28GhwS0yoeLYXpM2K8y6wzLwrbq814n2PHSoQ=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -1628,7 +1621,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
             "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
-            "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -2368,7 +2360,6 @@
             "version": "0.22.1",
             "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.22.1.tgz",
             "integrity": "sha512-TN7tzC2/jCM1/H/mlUjqPos8lIV+vm8Qwp83KofuZclGlG9PoUWHU7m0yqskjAoCy+R4ZCV0hxdBLPBkU69S2Q==",
-            "dev": true,
             "requires": {
                 "linguist-languages": "^7.27.0",
                 "mem": "^9.0.2",
@@ -3209,8 +3200,7 @@
         "linguist-languages": {
             "version": "7.27.0",
             "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.27.0.tgz",
-            "integrity": "sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw==",
-            "dev": true
+            "integrity": "sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw=="
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -3239,7 +3229,6 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
             "requires": {
                 "p-defer": "^1.0.0"
             }
@@ -3248,7 +3237,6 @@
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/mem/-/mem-9.0.2.tgz",
             "integrity": "sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==",
-            "dev": true,
             "requires": {
                 "map-age-cleaner": "^0.1.3",
                 "mimic-fn": "^4.0.0"
@@ -3273,8 +3261,7 @@
         "mimic-fn": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -3336,8 +3323,7 @@
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-            "dev": true
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw=="
         },
         "parent-module": {
             "version": "1.0.1",
@@ -3370,8 +3356,7 @@
         "php-parser": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.5.tgz",
-            "integrity": "sha512-jEY2DcbgCm5aclzBdfW86GM6VEIWcSlhTBSHN1qhJguVePlYe28GhwS0yoeLYXpM2K8y6wzLwrbq814n2PHSoQ==",
-            "dev": true
+            "integrity": "sha512-jEY2DcbgCm5aclzBdfW86GM6VEIWcSlhTBSHN1qhJguVePlYe28GhwS0yoeLYXpM2K8y6wzLwrbq814n2PHSoQ=="
         },
         "picomatch": {
             "version": "2.3.1",
@@ -3389,8 +3374,7 @@
         "prettier": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
-            "dev": true
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw=="
         },
         "progress": {
             "version": "2.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -14,9 +14,11 @@
         "url": "https://github.com/Stillat/vscode-antlers-language-server"
     },
     "dependencies": {
+        "@prettier/plugin-php": "^0.22",
         "file-uri-to-path": "^2.0.0",
         "js-beautify": "^1.13.13",
         "js-yaml": "^4.1.0",
+        "prettier": "^3",
         "semver": "^5.7.1",
         "ts-debounce": "^3.0.0",
         "ts-md5": "^1.2.9",
@@ -27,13 +29,11 @@
     },
     "scripts": {},
     "devDependencies": {
-        "@prettier/plugin-php": "^0.22",
         "@types/js-beautify": "^1.14.3",
         "@types/js-yaml": "^4.0.5",
         "@types/prettier": "^2.6.3",
         "@types/semver": "^7.3.5",
         "@typescript-eslint/parser": "^4.29.3",
-        "prettier": "^3",
         "typescript": "^4.4.2"
     }
 }

--- a/server/src/formatting/beautifyDocumentFormatter.ts
+++ b/server/src/formatting/beautifyDocumentFormatter.ts
@@ -3,6 +3,7 @@ import { AntlersFormattingOptions } from './antlersFormattingOptions.js';
 import { DocumentFormatter } from './documentFormatter.js';
 import { FrontMatterFormatter } from './frontMatterFormatter.js';
 import { getFormatOption, getTagsFormatOption } from './htmlCompat.js';
+import { formatPhp } from './phpFormatter.js';
 
 export class BeautifyDocumentFormatter extends DocumentFormatter {
     private options: AntlersFormattingOptions;
@@ -12,12 +13,18 @@ export class BeautifyDocumentFormatter extends DocumentFormatter {
 
         this.options = options;
         this.withHtmlFormatter(this.formatHtml)
+            .withAsyncHtmlFormatter(async (input) => this.formatHtml(input))
+            .withAsyncPhpFormatter((input) => formatPhp(input, {
+                tabWidth: options.tabSize,
+                useTabs: !options.insertSpaces
+            }))
             .withYamlFormatter(FrontMatterFormatter.formatFrontMatter)
             .withTransformOptions({
                 endNewline: getFormatOption(options.htmlOptions, "endWithNewline", false) as boolean,
                 maxAntlersStatementsPerLine: options.maxStatementsPerLine,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabSize
+                tabSize: options.tabSize,
+                insertSpaces: options.insertSpaces
             });
     }
 

--- a/server/src/formatting/cli/index.ts
+++ b/server/src/formatting/cli/index.ts
@@ -105,10 +105,10 @@ function getFiles(directory: string, extension: string, callback: fileCallback) 
     }
 }
 
-function formatString(contents: string, savePath: string|null, dumpContents: boolean, options: AntlersFormattingOptions) {
+async function formatString(contents: string, savePath: string|null, dumpContents: boolean, options: AntlersFormattingOptions) {
     const doc = AntlersDocument.fromText(contents),
         formatter = new BeautifyDocumentFormatter(options),
-        formatResults = formatter.formatDocument(doc, defaultAntlersSettings);
+        formatResults = await formatter.formatDocumentAsync(doc, defaultAntlersSettings);
     if (dumpContents === true) {
         console.log(formatResults);
     } else if (savePath != null) {
@@ -116,7 +116,7 @@ function formatString(contents: string, savePath: string|null, dumpContents: boo
     }
 }
 
-function formatFile(path: string, savePath: string, dumpContents: boolean, options: AntlersFormattingOptions) {
+async function formatFile(path: string, savePath: string, dumpContents: boolean, options: AntlersFormattingOptions) {
     if (fs.existsSync(path)) {
         try { fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK); } catch (err) { console.error(err); process.exit(EXIT_PATH_PERMISSIONS_ISSUE); }
 
@@ -124,7 +124,7 @@ function formatFile(path: string, savePath: string, dumpContents: boolean, optio
             const contents = fs.readFileSync(path, { encoding: 'utf8' }),
                 doc = AntlersDocument.fromText(contents),
                 formatter = new BeautifyDocumentFormatter(options),
-                formatResults = formatter.formatDocument(doc, defaultAntlersSettings);
+                formatResults = await formatter.formatDocumentAsync(doc, defaultAntlersSettings);
 
             if (dumpContents === true) {
                 console.log(formatResults);
@@ -140,15 +140,22 @@ function formatFile(path: string, savePath: string, dumpContents: boolean, optio
     }
 }
 
-function formatDirectory(dir: string, options: AntlersFormattingOptions, extensionsToUse: string[], dump: boolean) {
+async function formatDirectory(dir: string, options: AntlersFormattingOptions, extensionsToUse: string[], dump: boolean) {
     if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
         try { fs.accessSync(dir, fs.constants.R_OK | fs.constants.W_OK); } catch (err) { console.error(err); process.exit(EXIT_PATH_PERMISSIONS_ISSUE); }
 
+        const filesToFormat: string[] = [];
+
         extensionsToUse.forEach((extension) => {
             getFiles(dir, extension, (file) => {
-                formatFile(file, file, dump, options);
+                filesToFormat.push(file);
             });
         });
+
+        for (const file of filesToFormat) {
+            await formatFile(file, file, dump, options);
+        }
+
         process.exit(EXIT_SUCCESS);
     } else {
         process.exit(EXIT_FILE_NOT_FOUND);
@@ -178,7 +185,11 @@ function findSettings(root:string): string | null {
     return null;
 }
 
-if (argv._.includes('format')) {
+async function run() {
+    if (!argv._.includes('format')) {
+        return;
+    }
+
     let settingsToUse: AntlersFormattingOptions = defaultSettings;
 
     if (typeof argv.options !== 'undefined' && argv.options !== null) {
@@ -215,7 +226,7 @@ if (argv._.includes('format')) {
         if (argv.stdin === true) {
             const contents = fs.readFileSync(0, 'utf-8');
             
-            formatString(contents, argv.output, argv.dump === true, settingsToUse);
+            await formatString(contents, argv.output, argv.dump === true, settingsToUse);
             process.exit(EXIT_SUCCESS);
         }
 
@@ -232,7 +243,7 @@ if (argv._.includes('format')) {
                 extensionsToUse = defaultSettings.formatExtensions;
             }
 
-            formatDirectory(argv.dir, settingsToUse, extensionsToUse, argv.dump === true);
+            await formatDirectory(argv.dir, settingsToUse, extensionsToUse, argv.dump === true);
             process.exit(EXIT_SUCCESS);
         }
 
@@ -243,7 +254,7 @@ if (argv._.includes('format')) {
                 writePath = argv.output;
             }
 
-            formatFile(argv.path, writePath, argv.dump === true, settingsToUse);
+            await formatFile(argv.path, writePath, argv.dump === true, settingsToUse);
             process.exit(EXIT_SUCCESS);
         }
     } else {
@@ -267,7 +278,7 @@ if (argv._.includes('format')) {
                     extensionsToUse = defaultSettings.formatExtensions;
                 }
 
-                formatDirectory(path, settingsToUse, extensionsToUse, argv.dump === true);
+                await formatDirectory(path, settingsToUse, extensionsToUse, argv.dump === true);
             } else {
                 let writePath = path;
 
@@ -275,8 +286,13 @@ if (argv._.includes('format')) {
                     writePath = argv.output;
                 }
 
-                formatFile(path, writePath, argv.dump === true, settingsToUse);
+                await formatFile(path, writePath, argv.dump === true, settingsToUse);
             }
         }
     }
 }
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(EXIT_GENERAL_FAILURE);
+});

--- a/server/src/formatting/formatter.ts
+++ b/server/src/formatting/formatter.ts
@@ -8,7 +8,7 @@ import { AntlersFormattingOptions } from './antlersFormattingOptions.js';
 import { BeautifyDocumentFormatter } from './beautifyDocumentFormatter.js';
 import { IHTMLFormatConfiguration } from "./htmlCompat.js";
 
-export function formatAntlersDocument(params: DocumentFormattingParams): TextEdit[] | null {
+export async function formatAntlersDocument(params: DocumentFormattingParams): Promise<TextEdit[] | null> {
     const settings = getAntlersSettings();
     const documentPath = decodeURIComponent(params.textDocument.uri);
     const options = htmlFormatterSettings.format as IHTMLFormatConfiguration;
@@ -35,7 +35,7 @@ export function formatAntlersDocument(params: DocumentFormattingParams): TextEdi
             };
 
         const formatter = new BeautifyDocumentFormatter(antlersFormatterOptions),
-            results = formatter.formatDocument(antlersDoc, getAntlersSettings());
+            results = await formatter.formatDocumentAsync(antlersDoc, getAntlersSettings());
 
         const replaceEndPosition = document.positionAt(docText.length);
 

--- a/server/src/formatting/phpFormatter.ts
+++ b/server/src/formatting/phpFormatter.ts
@@ -1,0 +1,61 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import php from '@prettier/plugin-php/standalone';
+import type { Options } from 'prettier';
+import * as prettier from 'prettier/standalone';
+
+const phpPlugin = {
+    ...php,
+    options: {
+        ...php.options,
+        singleQuote: {
+            category: 'Common',
+            type: 'boolean',
+            default: false,
+            description: 'Use single quotes instead of double quotes.'
+        }
+    }
+};
+
+const internalOptionNames = [
+    'cursorOffset',
+    'rangeEnd',
+    'rangeStart',
+    'locEnd',
+    'locStart',
+    'printer',
+    'originalText',
+    'astFormat'
+];
+
+function cleanOptions(options: Options): Options {
+    const cleanedOptions = { ...options } as Record<string, unknown>;
+
+    internalOptionNames.forEach((optionName) => {
+        delete cleanedOptions[optionName];
+    });
+
+    return cleanedOptions as Options;
+}
+
+export async function formatPhp(text: string, options: Options = {}): Promise<string> {
+    const originalPhp = text.trim();
+    let result = (await prettier.format(`<?php ${text}`, {
+        singleQuote: false,
+        ...cleanOptions(options),
+        parser: 'php',
+        plugins: [phpPlugin]
+    })).trim();
+
+    if (!result.startsWith('<?php')) {
+        throw new Error('Unable to locate the temporary PHP opening tag.');
+    }
+
+    result = result.substring(5).trim();
+
+    if (!originalPhp.endsWith(';') && result.endsWith(';')) {
+        result = result.substring(0, result.length - 1);
+    }
+
+    return result.trim();
+}

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -1,8 +1,9 @@
 import { DocumentFormatter } from '../documentFormatter.js';
 import * as prettier from 'prettier';
-import { formatAsHtml, formatPhp, setOptions } from './utils.js';
+import { formatAsHtml, setOptions } from './utils.js';
 import { FrontMatterFormatter } from '../frontMatterFormatter.js';
 import { ErrorPrinter } from '../../runtime/document/printers/errorPrinter.js';
+import { formatPhp } from '../phpFormatter.js';
 
 export class PrettierDocumentFormatter extends DocumentFormatter {
 
@@ -18,9 +19,10 @@ export class PrettierDocumentFormatter extends DocumentFormatter {
                 endNewline: true,
                 maxAntlersStatementsPerLine: 3,
                 newlinesAfterFrontMatter: 1,
-                tabSize: options.tabWidth
+                tabSize: options.tabWidth,
+                insertSpaces: options.useTabs !== true
             })
-            .withAsyncPhpFormatter(formatPhp)
+            .withAsyncPhpFormatter((input) => formatPhp(input, options))
             .withPreFormatter((document) => {
                 if (document.errors.hasStructureErrors()) {
                     const firstError = document.errors.getFirstStructureError(),

--- a/server/src/formatting/prettier/utils.ts
+++ b/server/src/formatting/prettier/utils.ts
@@ -1,12 +1,7 @@
 import * as prettier from 'prettier';
 import plugin from './plugin.js';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import php from "@prettier/plugin-php/standalone";
-
-let phpOptions: prettier.ParserOptions,
-    htmlOptions: prettier.ParserOptions;
+let htmlOptions: prettier.ParserOptions;
 
 export function cleanOptions(options: prettier.ParserOptions): prettier.ParserOptions {
     [
@@ -32,38 +27,20 @@ export function setOptions(options: prettier.ParserOptions) {
             { htmlWhitespaceSensitivity: "ignore", parser: "html", plugins: options.plugins }
         )
     );
-
-    phpOptions = cleanOptions(
-        Object.assign({}, options, {
-            parser: 'php',
-            plugins: [php]
-        })
-    );
 }
 
 export function getHtmlOptions(): prettier.ParserOptions {
     return htmlOptions as prettier.ParserOptions;
 }
 
-export async function formatPhp(text: string): Promise<string> {
-    let result = (await prettier.format('<?php ' + text, phpOptions)).trim();
-
-    result = result.substring(5);
-
-    if (text.endsWith(';') == false && result.endsWith(';')) {
-        result = result.substring(0, result.length - 1);
-    }
-
-    return result.trim();
-}
-
 export function formatAsHtml(text: string) {
     return prettier.format(text, htmlOptions);
 }
 
-export function formatStringWithPrettier(text: string) {
+export function formatStringWithPrettier(text: string, options: prettier.Options = {}) {
     return prettier.format(text, {
         parser: 'antlers',
-        plugins: [plugin as any as string]
+        plugins: [plugin as any as string],
+        ...options
     });
 }

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -1,5 +1,6 @@
 export interface TransformOptions {
     tabSize: number,
+    insertSpaces: boolean,
     newlinesAfterFrontMatter: number,
     maxAntlersStatementsPerLine: number,
     endNewline: boolean

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -98,6 +98,7 @@ export class Transformer {
 
         this.options = {
             tabSize: 4,
+            insertSpaces: true,
             newlinesAfterFrontMatter: 1,
             maxAntlersStatementsPerLine: 3,
             endNewline: true
@@ -310,8 +311,10 @@ export class Transformer {
             try {
                 const formattedPhp = await this.asyncPhpFormatter(printNode.content);
 
-                return `${printNode.rawStart} ${formattedPhp} ${printNode.rawEnd}`;
-            } catch (err) { }
+                return this.printPhpNode(printNode, formattedPhp, targetIndent);
+            } catch (err) {
+                return `${printNode.rawStart}${printNode.sourceContent}${printNode.rawEnd}`;
+            }
         }
 
         let doc = this.doc;
@@ -360,8 +363,10 @@ export class Transformer {
             try {
                 const formattedPhp = this.phpFormatter(printNode.content);
 
-                return `${printNode.rawStart} ${formattedPhp} ${printNode.rawEnd}`;
-            } catch (err) { }
+                return this.printPhpNode(printNode, formattedPhp, targetIndent);
+            } catch (err) {
+                return `${printNode.rawStart}${printNode.sourceContent}${printNode.rawEnd}`;
+            }
         }
 
         let doc = this.doc;
@@ -401,6 +406,97 @@ export class Transformer {
         }
 
         return result;
+    }
+
+    private printPhpNode(node: AntlersNode, formattedPhp: string, targetIndent: number | null): string {
+        const normalizedPhp = formattedPhp.trim().replace(/\r\n?/g, '\n');
+
+        if (!normalizedPhp.includes('\n')) {
+            return `${node.rawStart} ${normalizedPhp} ${node.rawEnd}`;
+        }
+
+        const indentCount = Math.max(0, targetIndent ?? 0),
+            outerIndent = this.options.insertSpaces ? ' '.repeat(indentCount) : '\t'.repeat(indentCount),
+            indentUnit = this.options.insertSpaces ? ' '.repeat(this.options.tabSize) : '\t',
+            bodyIndent = outerIndent + indentUnit,
+            indentedPhp = this.indentPhpLines(normalizedPhp, bodyIndent);
+
+        return `${node.rawStart}\n${indentedPhp}\n${outerIndent}${node.rawEnd}`;
+    }
+
+    private indentPhpLines(php: string, indent: string): string {
+        let activeQuote: string | null = null,
+            heredocLabel: string | null = null,
+            insideBlockComment = false;
+
+        return php.split('\n').map((line) => {
+            const shouldIndent = activeQuote == null,
+                output = line.length == 0 ? '' : (shouldIndent ? indent : '') + line;
+
+            if (heredocLabel != null) {
+                const escapedLabel = heredocLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+                    closingPattern = new RegExp(`^\\s*${escapedLabel}(?:[;,)]|$)`);
+
+                if (closingPattern.test(line)) {
+                    heredocLabel = null;
+                }
+
+                return output;
+            }
+
+            for (let i = 0; i < line.length; i++) {
+                const current = line[i],
+                    next = line[i + 1] ?? '';
+
+                if (activeQuote != null) {
+                    if (current == '\\') {
+                        i += 1;
+                        continue;
+                    }
+
+                    if (current == activeQuote) {
+                        activeQuote = null;
+                    }
+
+                    continue;
+                }
+
+                if (insideBlockComment) {
+                    if (current == '*' && next == '/') {
+                        insideBlockComment = false;
+                        i += 1;
+                    }
+
+                    continue;
+                }
+
+                if (current == '/' && next == '*') {
+                    insideBlockComment = true;
+                    i += 1;
+                    continue;
+                }
+
+                if ((current == '/' && next == '/') || (current == '#' && next != '[')) {
+                    break;
+                }
+
+                if (current == '\'' || current == '"' || current == '`') {
+                    activeQuote = current;
+                    continue;
+                }
+
+                if (current == '<' && line.substring(i).startsWith('<<<')) {
+                    const heredocMatch = /^<<<[ \t]*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/.exec(line.substring(i));
+
+                    if (heredocMatch != null) {
+                        heredocLabel = heredocMatch[1];
+                        break;
+                    }
+                }
+            }
+
+            return output;
+        }).join('\n');
     }
 
 

--- a/server/src/test/formatter_php.test.ts
+++ b/server/src/test/formatter_php.test.ts
@@ -1,0 +1,108 @@
+import assert from 'assert';
+import { AntlersFormattingOptions } from '../formatting/antlersFormattingOptions.js';
+import { formatAntlersAsync } from './testUtils/formatAntlers.js';
+
+const tabOptions: AntlersFormattingOptions = {
+    htmlOptions: { wrapLineLength: 500 },
+    tabSize: 4,
+    insertSpaces: false,
+    formatFrontMatter: true,
+    maxStatementsPerLine: 3,
+    formatExtensions: []
+};
+
+suite('Formatter PHP', () => {
+    test('it formats both PHP node styles', async () => {
+        const input = `<span>{{? $register =             route(      'account.register'          ); ?}}</span>
+<span>{{$        route(      'account.register'          )     $}}</span>`,
+            expected = `<span>{{? $register = route("account.register"); ?}}</span>
+<span>{{$ route("account.register") $}}</span>`;
+
+        assert.strictEqual(await formatAntlersAsync(input), expected);
+    });
+
+    test('it formats multiline PHP at nested indentation levels', async () => {
+        const input = `<main>
+<section>
+{{?
+$items=[1,2,3];
+if(count($items)>0){
+echo 'ready';
+}
+?}}
+</section>
+</main>`,
+            expected = `<main>
+    <section>
+        {{?
+            $items = [1, 2, 3];
+            if (count($items) > 0) {
+                echo "ready";
+            }
+        ?}}
+    </section>
+</main>`,
+            once = await formatAntlersAsync(input),
+            twice = await formatAntlersAsync(once);
+
+        assert.strictEqual(once, expected);
+        assert.strictEqual(twice, expected);
+    });
+
+    test('it respects tab indentation inside multiline PHP', async () => {
+        const input = `<main>
+<section>
+{{$ $items=[1,2,3];if(count($items)>0){return 'ready';} $}}
+</section>
+</main>`,
+            expected = `<main>
+\t<section>
+\t\t{{$
+\t\t\t$items = [1, 2, 3];
+\t\t\tif (count($items) > 0) {
+\t\t\t\treturn "ready";
+\t\t\t}
+\t\t$}}
+\t</section>
+</main>`,
+            once = await formatAntlersAsync(input, tabOptions),
+            twice = await formatAntlersAsync(once, tabOptions);
+
+        assert.strictEqual(once, expected);
+        assert.strictEqual(twice, expected);
+    });
+
+    test('it preserves invalid PHP exactly', async () => {
+        const input = `<span>{{$        route(      'account.register'          ) ++++++     $}}</span>`;
+
+        assert.strictEqual(await formatAntlersAsync(input), input);
+    });
+
+    test('it does not change multiline string values while indenting PHP', async () => {
+        const input = `<section>
+{{?
+$message = "hello
+world";
+$document = <<<TEXT
+hello
+  world
+TEXT;
+?}}
+</section>`,
+            expected = `<section>
+    {{?
+        $message = "hello
+world";
+        $document = <<<TEXT
+        hello
+          world
+        TEXT;
+    ?}}
+</section>`,
+            once = await formatAntlersAsync(input),
+            twice = await formatAntlersAsync(once);
+
+        assert.strictEqual(once, expected);
+        assert.strictEqual(twice, expected);
+    });
+});

--- a/server/src/test/formatter_prettier_php.test.ts
+++ b/server/src/test/formatter_prettier_php.test.ts
@@ -2,13 +2,72 @@ import assert from 'assert';
 import { formatStringWithPrettier } from '../formatting/prettier/utils.js';
 
 suite('Formatter Prettier PHP', () => {
+    test('it formats multiline PHP at nested indentation levels', async () => {
+        const input = `<main>
+<section>
+{{?
+$items=[1,2,3];
+if(count($items)>0){
+echo 'ready';
+}
+?}}
+</section>
+</main>`,
+            expected = `<main>
+    <section>
+        {{?
+            $items = [1, 2, 3];
+            if (count($items) > 0) {
+                echo "ready";
+            }
+        ?}}
+    </section>
+</main>\n`,
+            once = await formatStringWithPrettier(input),
+            twice = await formatStringWithPrettier(once);
+
+        assert.strictEqual(once, expected);
+        assert.strictEqual(twice, expected);
+    });
+
+    test('it respects tab indentation inside multiline PHP', async () => {
+        const input = `<main>
+<section>
+{{$ $items=[1,2,3];if(count($items)>0){return 'ready';} $}}
+</section>
+</main>`,
+            expected = `<main>
+\t<section>
+\t\t{{$
+\t\t\t$items = [1, 2, 3];
+\t\t\tif (count($items) > 0) {
+\t\t\t\treturn "ready";
+\t\t\t}
+\t\t$}}
+\t</section>
+</main>\n`,
+            options = { useTabs: true, tabWidth: 4 },
+            once = await formatStringWithPrettier(input, options),
+            twice = await formatStringWithPrettier(once, options);
+
+        assert.strictEqual(once, expected);
+        assert.strictEqual(twice, expected);
+    });
+
+    test('it respects the configured PHP quote style', async () => {
+        const input = `<span>{{? route("account.register"); ?}}</span>`,
+            expected = `<span>{{? route('account.register'); ?}}</span>\n`;
+
+        assert.strictEqual(await formatStringWithPrettier(input, { singleQuote: true }), expected);
+    });
+
     test('it can format PHP nodes', async () => {
         assert.strictEqual(
             (await formatStringWithPrettier(`
             <span>{{? $register =             route(      'account.register'          ); ?}}</span>
             <span>     {{$        route(      'account.register'          )     $}}</span>
             <span>       {{$        route(      'account.register'          ) ++++++     $}}</span> `)).trim(),
-            `<span>{{? $register = route("account.register") ?}}</span>
+            `<span>{{? $register = route("account.register"); ?}}</span>
 <span>{{$ route("account.register") $}}</span>
 <span>{{$        route(      'account.register'          ) ++++++     $}}</span>`
         );

--- a/server/src/test/testUtils/formatAntlers.ts
+++ b/server/src/test/testUtils/formatAntlers.ts
@@ -38,3 +38,11 @@ export function formatAntlers(text: string, options: AntlersFormattingOptions | 
 
     return (new BeautifyDocumentFormatter(options)).formatDocument(AntlersDocument.fromText(text), defaultAntlersSettings);
 }
+
+export async function formatAntlersAsync(text: string, options: AntlersFormattingOptions | null = null): Promise<string> {
+    if (options == null) {
+        options = antlersOptions;
+    }
+
+    return (new BeautifyDocumentFormatter(options)).formatDocumentAsync(AntlersDocument.fromText(text), defaultAntlersSettings);
+}


### PR DESCRIPTION
## Summary

- format embedded PHP through the VS Code formatter, Prettier plugin, and formatter CLI
- render multiline PHP as indentation-aware blocks across nested spaces and tabs
- preserve invalid PHP, authored semicolons, multiline string values, and heredoc contents
- honor Prettier's PHP quote and indentation options

## Verification

- `npm run test:server` — 292 passing
- 60-case indentation matrix — 360 checks passing across both delimiters, spaces/tabs, tab widths 2/4/8, nesting levels 0–4, surface parity, and repeated formatting
- CLI and Prettier bundle smoke tests — stable across repeated formatting
- language-server bundle smoke — passing
- production PHP formatter dependencies — resolved

Fixes #86