### PR TITLE
Normalize preserved array indentation

### DIFF
--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -44,45 +44,42 @@ export class NodePrinter {
      * Brackets are numbered per node: the opening brackets of a name come
      * first, followed by its closing brackets.
      */
-    private static resolveArrayWrapping(lexerNodes: AbstractNode[], options: TransformOptions, doc: AntlersDocument): Map<string, ArrayWrapLayout> {
+    private static resolveArrayWrapping(lexerNodes: AbstractNode[], options: TransformOptions): Map<string, ArrayWrapLayout> {
         const decisions: Map<string, ArrayWrapLayout> = new Map(),
-            openBrackets: ArrayBracket[] = [];
+            openBrackets: ArrayBracket[] = [],
+            indentUnit = options.insertSpaces
+                ? ' '.repeat(options.tabSize)
+                : '\t';
 
         for (let i = 0; i < lexerNodes.length; i++) {
             const node = lexerNodes[i],
                 line = node.startPosition?.line ?? 0;
 
             if (!(node instanceof VariableNode)) {
-                NodePrinter.markArrayItems(openBrackets, node, doc);
+                NodePrinter.markArrayItems(openBrackets);
                 continue;
             }
 
             const parts = NodePrinter.splitArrayBrackets(node.name);
 
             if (parts == null) {
-                NodePrinter.markArrayItems(openBrackets, node, doc);
+                NodePrinter.markArrayItems(openBrackets);
                 continue;
             }
 
             for (let b = 0; b < parts.openCount; b++) {
-                NodePrinter.markArrayItems(openBrackets, node, doc);
-
-                const rootIndent = openBrackets.length > 0
-                    ? openBrackets[0].rootIndent
-                    : NodePrinter.sourceIndent(node, doc);
+                NodePrinter.markArrayItems(openBrackets);
 
                 openBrackets.push({
                     key: NodePrinter.bracketKey(i, b),
                     line: line,
                     hasItems: false,
-                    rootIndent: rootIndent,
-                    itemIndent: null,
                     depth: openBrackets.length + 1
                 });
             }
 
             if (parts.value.length > 0) {
-                NodePrinter.markArrayItems(openBrackets, node, doc);
+                NodePrinter.markArrayItems(openBrackets);
             }
 
             for (let b = 0; b < parts.closeCount; b++) {
@@ -91,18 +88,12 @@ export class NodePrinter {
                 if (bracket == null) { continue; }
 
                 const wrap = bracket.hasItems && line > bracket.line,
-                    closeKey = NodePrinter.bracketKey(i, parts.openCount + b),
-                    parentBracket = openBrackets.length > 0
-                        ? openBrackets[openBrackets.length - 1]
-                        : null,
-                    closeIndent = parts.closeCount > 1
-                        ? parentBracket?.itemIndent ?? ''
-                        : NodePrinter.relativeIndent(NodePrinter.sourceIndent(node, doc, true), bracket.rootIndent);
+                    closeKey = NodePrinter.bracketKey(i, parts.openCount + b);
 
                 const layout: ArrayWrapLayout = {
                     wrap: wrap,
-                    itemIndent: bracket.itemIndent ?? ' '.repeat(options.tabSize * bracket.depth),
-                    closeIndent: closeIndent
+                    itemIndent: indentUnit.repeat(bracket.depth),
+                    closeIndent: indentUnit.repeat(Math.max(0, bracket.depth - 1))
                 };
 
                 decisions.set(bracket.key, layout);
@@ -113,46 +104,10 @@ export class NodePrinter {
         return decisions;
     }
 
-    private static markArrayItems(openBrackets: ArrayBracket[], node: AbstractNode, doc: AntlersDocument) {
-        const line = node.startPosition?.line ?? 0,
-            sourceIndent = NodePrinter.sourceIndent(node, doc),
-            rootIndent = openBrackets[0]?.rootIndent ?? '',
-            relativeIndent = NodePrinter.relativeIndent(sourceIndent, rootIndent),
-            currentDepth = openBrackets.length;
-
+    private static markArrayItems(openBrackets: ArrayBracket[]) {
         openBrackets.forEach((bracket) => {
             bracket.hasItems = true;
-
-            if (bracket.itemIndent == null && line > bracket.line) {
-                const targetLength = bracket.depth == currentDepth
-                    ? relativeIndent.length
-                    : Math.round(relativeIndent.length * (bracket.depth / currentDepth));
-
-                bracket.itemIndent = relativeIndent.substring(0, targetLength);
-            }
         });
-    }
-
-    private static sourceIndent(node: AbstractNode, doc: AntlersDocument, useEndPosition = false): string {
-        const content = doc.getOriginalContent(),
-            index = Math.max(0, (useEndPosition ? node.endPosition?.index : node.startPosition?.index) ?? 0),
-            lineStart = content.lastIndexOf("\n", index - 1) + 1,
-            lineEndCandidate = content.indexOf("\n", index),
-            lineEnd = lineEndCandidate == -1 ? content.length : lineEndCandidate,
-            line = content.substring(lineStart, lineEnd);
-
-        return (/^[\t ]*/.exec(line) ?? [''])[0];
-    }
-
-    private static relativeIndent(indent: string, rootIndent: string): string {
-        let sharedLength = 0;
-
-        while (sharedLength < indent.length && sharedLength < rootIndent.length &&
-            indent[sharedLength] == rootIndent[sharedLength]) {
-            sharedLength += 1;
-        }
-
-        return indent.substring(sharedLength);
     }
 
     private static hasLineBreakAfter(node: AbstractNode, nextNode: AbstractNode, doc: AntlersDocument): boolean {
@@ -203,7 +158,7 @@ export class NodePrinter {
         const arrayWrapStack: ArrayPrintLayout[] = [],
             arrayWrapDecisions = options.arrayWrap == 'collapse'
                 ? new Map<string, ArrayWrapLayout>()
-                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
+                : NodePrinter.resolveArrayWrapping(lexerNodes, options);
         let nodeStatements = 0,
             nodeOperators = 0,
             arrayLiteralDepth = 0;
@@ -697,8 +652,6 @@ interface ArrayBracket {
     key: string,
     line: number,
     hasItems: boolean,
-    rootIndent: string,
-    itemIndent: string | null,
     depth: number
 }
 

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -172,6 +172,13 @@ export class Transformer {
         return this;
     }
 
+    private hasArrayLiteral(node: AntlersNode): boolean {
+        return node.getTrueNode().getTrueRuntimeNodes().some((runtimeNode) =>
+            runtimeNode instanceof VariableNode &&
+            (runtimeNode.name.startsWith('[') || runtimeNode.name.endsWith(']'))
+        );
+    }
+
     setParentTransformer(transformer: Transformer) {
         this.parentTransformer = transformer;
 
@@ -747,10 +754,7 @@ export class Transformer {
         if (this.parentTransformer != null) {
             return this.parentTransformer.registerInlineAntlers(node);
         } else {
-            const containsArray = node.getTrueRuntimeNodes().some((runtimeNode) =>
-                    runtimeNode instanceof VariableNode &&
-                    (runtimeNode.name.startsWith('[') || runtimeNode.name.endsWith(']'))
-                ),
+            const containsArray = this.hasArrayLiteral(node),
                 slugLength = containsArray
                     ? this.printNode(node).length
                     : node.getOriginalContent().length,
@@ -943,7 +947,10 @@ export class Transformer {
         for (const [slug, node] of this.inlineNodes) {
             const inline = this.selfClosing(slug),
                 inlineNs = this.selfClosingNs(slug),
-                printed = await this.printNodeAsync(node, this.indentLevel(inline));
+                preserveArrayIndent = this.options.arrayWrap == 'preserve' && this.hasArrayLiteral(node),
+                printed = preserveArrayIndent
+                    ? this.shiftSpanNode(await this.printNodeAsync(node), inline, 0)
+                    : await this.printNodeAsync(node, this.indentLevel(inline));
             value = value.replace(inline, printed);
             value = value.replace(inlineNs, printed);
         }
@@ -1020,7 +1027,10 @@ export class Transformer {
         this.inlineNodes.forEach((node: AntlersNode, slug: string) => {
             const inline = this.selfClosing(slug),
                 inlineNs = this.selfClosingNs(slug),
-                printed = this.printNode(node, this.indentLevel(inline));
+                preserveArrayIndent = this.options.arrayWrap == 'preserve' && this.hasArrayLiteral(node),
+                printed = preserveArrayIndent
+                    ? this.shiftSpanNode(this.printNode(node), inline, 0)
+                    : this.printNode(node, this.indentLevel(inline));
             value = value.replace(inline, printed);
             value = value.replace(inlineNs, printed);
         });

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -46,18 +46,34 @@ suite('Formatter Array Wrapping', () => {
         assert.strictEqual(formatAntlers(input, formattingOptions('invalid')), input);
     });
 
-    test('preserved arrays retain tabs and nested indentation', () => {
-        const input = `{{ [
-\t'one',
-\t[
-\t\t'two'
-\t]
-] | classes }}`;
+    test('preserved arrays normalize nested indentation', () => {
+        const input = `{{
+    test = [
+            'one' => 1,
+            'two' => 2,
+            'nested' => [
+            'one' => 1,
+            'two' => 2,
 
-        assert.strictEqual(formatAntlers(input), input);
+    ]
+        ]
+}}`,
+            expected = `{{ test = [
+    'one' => 1,
+    'two' => 2,
+    'nested' => [
+        'one' => 1,
+        'two' => 2,
+    ]
+] }}`;
+
+        const firstPass = formatAntlers(input, formattingOptions('preserve'));
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, formattingOptions('preserve')), firstPass);
     });
 
-    test('preserved arrays retain authored indentation widths', () => {
+    test('preserved arrays use configured indentation widths', () => {
         const inputs = [
             `{{ [
   'one',
@@ -76,9 +92,64 @@ suite('Formatter Array Wrapping', () => {
         inputs.forEach((input) => {
             const firstPass = formatAntlers(input);
 
-            assert.strictEqual(firstPass, input);
+            assert.strictEqual(firstPass, `{{ [
+    'one',
+    [
+        'two'
+    ]
+] }}`);
             assert.strictEqual(formatAntlers(firstPass), firstPass);
         });
+    });
+
+    test('preserved nested arrays use configured tabs', () => {
+        const input = `{{ values = [
+        'one' => [
+        'two' => [
+        'three'
+]
+]
+] }}`,
+            expected = `{{ values = [
+\t'one' => [
+\t\t'two' => [
+\t\t\t'three'
+\t\t]
+\t]
+] }}`,
+            options = formattingOptions('preserve', false),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('preserved arrays retain their formatted leading indentation', () => {
+        const input = `        {{ values = [
+                    ['alpha'],
+                    [],
+                    [
+                    'beta',
+                    'gamma',
+            ]
+                ]
+         after = values[2][1] }}`,
+            expected = `        {{ values = [
+            ['alpha'],
+            [],
+            [
+                'beta',
+                'gamma',
+            ]
+        ]
+         after = values[2][1] }}`;
+
+        let output = input;
+
+        for (let pass = 0; pass < 5; pass++) {
+            output = formatAntlers(output, formattingOptions('preserve'));
+            assert.strictEqual(output, expected);
+        }
     });
 
     test('tabs remain stable inside nested HTML', () => {

--- a/server/src/test/formatter_operators.test.ts
+++ b/server/src/test/formatter_operators.test.ts
@@ -196,9 +196,9 @@ source }}`,
             'one' => 1,
             'two' => 2	
         ] }}`), `{{ test = [
-            'one' => 1,
-            'two' => 2
-        ] }}`);
+    'one' => 1,
+    'two' => 2
+] }}`);
     });
 
     test('it emits strings', () => {

--- a/server/src/test/formatter_prettier_array_wrap.test.ts
+++ b/server/src/test/formatter_prettier_array_wrap.test.ts
@@ -117,18 +117,33 @@ suite('Prettier Formatter Array Wrapping', () => {
         assert.strictEqual((await formatCollapsed(input)).trim(), `{{ [one, 'two', three] }}`);
     });
 
-    test('preserved arrays retain tabs and nested indentation', async () => {
-        const input = `{{ [
-\t'one',
-\t[
-\t\t'two'
-\t]
-] | classes }}`;
+    test('preserved arrays normalize nested indentation', async () => {
+        const input = `{{
+    test = [
+            'one' => 1,
+            'two' => 2,
+            'nested' => [
+            'one' => 1,
+            'two' => 2,
 
-        assert.strictEqual((await formatStringWithPrettier(input)).trim(), input);
+    ]
+        ]
+}}`,
+            expected = `{{ test = [
+    'one' => 1,
+    'two' => 2,
+    'nested' => [
+        'one' => 1,
+        'two' => 2,
+    ]
+] }}`,
+            firstPass = await formatPreserved(input);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatPreserved(firstPass), firstPass);
     });
 
-    test('preserved arrays retain authored indentation widths', async () => {
+    test('preserved arrays use configured indentation widths', async () => {
         const inputs = [
             `{{ [
   'one',
@@ -147,9 +162,36 @@ suite('Prettier Formatter Array Wrapping', () => {
         for (const input of inputs) {
             const firstPass = await formatPreserved(input);
 
-            assert.strictEqual(firstPass.trim(), input);
+            assert.strictEqual(firstPass.trim(), `{{ [
+    'one',
+    [
+        'two'
+    ]
+] }}`);
             assert.strictEqual(await formatPreserved(firstPass), firstPass);
         }
+    });
+
+    test('preserved nested arrays use configured tabs', async () => {
+        const input = `{{ values = [
+        'one' => [
+        'two' => [
+        'three'
+]
+]
+] }}`,
+            expected = `{{ values = [
+\t'one' => [
+\t\t'two' => [
+\t\t\t'three'
+\t\t]
+\t]
+] }}`,
+            options = { antlersArrayWrap: 'preserve', useTabs: true, tabWidth: 4 } as any,
+            firstPass = await formatStringWithPrettier(input, options);
+
+        assert.strictEqual(firstPass.trim(), expected);
+        assert.strictEqual(await formatStringWithPrettier(firstPass, options), firstPass);
     });
 
     test('tabs remain stable inside nested HTML', async () => {


### PR DESCRIPTION
## Summary

- normalize preserved array indentation by structural nesting depth
- retain authored multiline versus inline wrapping decisions
- honor configured space widths and tabs across core and Prettier formatting
- keep leading indentation and repeated formatting stable

Follow-up to #118 after its original merge.

## Verification

- `npm run test:server` — 330 passing
- focused array and operator tests — 71 passing
- 64 core/Prettier indentation and idempotence checks across spaces, tabs, and nesting depths 1–4