### PR TITLE
Fix project detail notifications

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -6,7 +6,7 @@ import {
     languages, SemanticTokensLegend,
     DocumentSemanticTokensProvider, DocumentRangeSemanticTokensProvider, SemanticTokens
 } from 'vscode';
-import { RequestType, TextDocumentIdentifier, RequestType0, Range as LspRange, DidOpenTextDocumentNotification } from 'vscode-languageclient';
+import { RequestType, TextDocumentIdentifier, RequestType0, Range as LspRange, DidOpenTextDocumentNotification, NotificationType } from 'vscode-languageclient';
 import { debounce } from 'ts-debounce';
 import { activateAntlersDebug } from './debug/activateAntlersDebug';
 import { TimingsLensProvider } from './debug/timingsLensProvider';
@@ -83,8 +83,8 @@ interface ProjectDetailsParams {
     content: IProjectFields;
 }
 
-namespace ProjectUpdatedRequest {
-    export const type: RequestType<ProjectDetailsParams, null, any> = new RequestType('antlers/projectDetailsAvailable');
+namespace ProjectUpdatedNotification {
+    export const type = new NotificationType<ProjectDetailsParams>('antlers/projectDetailsAvailable');
 }
 
 namespace SemanticTokenRequest {
@@ -245,7 +245,7 @@ export function activate(context: ExtensionContext) {
 
         isClientReady = true;
 
-        client.onRequest(ProjectUpdatedRequest.type, (f) => {
+        client.onNotification(ProjectUpdatedNotification.type, (f) => {
             if (projectExplorer != null) {
                 projectExplorer.updateStructure(f.content);
             }

--- a/server/src/protocol/projectDetailsNotification.ts
+++ b/server/src/protocol/projectDetailsNotification.ts
@@ -1,0 +1,25 @@
+import { NotificationType } from "vscode-languageserver/node.js";
+import { IProjectFields } from "../projects/structuredFieldTypes/types.js";
+
+export interface ProjectDetailsParams {
+    content: IProjectFields;
+}
+
+export const ProjectDetailsAvailableNotification =
+    new NotificationType<ProjectDetailsParams>("antlers/projectDetailsAvailable");
+
+interface ProjectDetailsNotificationSender {
+    sendNotification(
+        type: NotificationType<ProjectDetailsParams>,
+        params: ProjectDetailsParams
+    ): void;
+}
+
+export function notifyProjectDetails(
+    sender: ProjectDetailsNotificationSender,
+    contents: IProjectFields
+): void {
+    sender.sendNotification(ProjectDetailsAvailableNotification, {
+        content: contents
+    });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -68,6 +68,7 @@ import { DocumentationHandler } from './documentation/generator/handler.js';
 import { IProjectFields } from './projects/structuredFieldTypes/types.js';
 import { IDocumentationResult } from './documentation/generator/types.js';
 import { updateCurrentDetails } from './documentation/generator/documentationProvider.js';
+import { notifyProjectDetails } from './protocol/projectDetailsNotification.js';
 
 const defaultSettings: AntlersSettings = {
     formatFrontMatter: false,
@@ -116,10 +117,6 @@ interface ForcedFormatParams {
 
 interface DocumentTransformParams {
     content: string
-}
-
-interface ProjectDetailsParams {
-    content: IProjectFields
 }
 
 interface TransformReplacement {
@@ -493,11 +490,7 @@ export function requestEdits(edit: WorkspaceEdit) {
 export function sendProjectDetails(contents: IProjectFields) {
     ProjectManager.instance?.setStructuredProject(contents);
     updateCurrentDetails(contents);
-    const params: ProjectDetailsParams = {
-        content: contents
-    };
-
-    connection.sendRequest("antlers/projectDetailsAvailable", params);
+    notifyProjectDetails(connection, contents);
 }
 
 function analyzeStructures(document: string) {

--- a/server/src/test/project_details_notification.test.ts
+++ b/server/src/test/project_details_notification.test.ts
@@ -1,0 +1,39 @@
+import assert from "assert";
+import { NotificationType } from "vscode-languageserver/node.js";
+import {
+    notifyProjectDetails,
+    ProjectDetailsAvailableNotification,
+    ProjectDetailsParams
+} from "../protocol/projectDetailsNotification.js";
+import { IProjectFields } from "../projects/structuredFieldTypes/types.js";
+
+const projectDetails: IProjectFields = {
+    assets: [],
+    collections: [],
+    taxonomies: [],
+    navigations: [],
+    forms: [],
+    general: [],
+    globals: [],
+    fieldsets: []
+};
+
+suite("Project Details Notification", () => {
+    test("it publishes project details as a notification", () => {
+        const sent: {
+            type?: NotificationType<ProjectDetailsParams>,
+            params?: ProjectDetailsParams
+        } = {};
+
+        notifyProjectDetails({
+            sendNotification(type, params) {
+                sent.type = type;
+                sent.params = params;
+            }
+        }, projectDetails);
+
+        assert.strictEqual(sent.type, ProjectDetailsAvailableNotification);
+        assert.strictEqual(sent.type?.method, "antlers/projectDetailsAvailable");
+        assert.strictEqual(sent.params?.content, projectDetails);
+    });
+});


### PR DESCRIPTION
## Summary

- publish project details as a one-way LSP notification
- keep VS Code project explorer updates without requiring other clients to implement a private request
- preserve internal project model updates and add focused notification coverage

Prevents the non-VS Code crash reported in #59 from recurring.

## Verification

- `npm run test:server` — 395 passing
- `npm run test:client` — 14 passing