### PR TITLE
Run tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / Node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        node:
+          - 22
+          - 24
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install client dependencies
+        run: npm ci --prefix client
+
+      - name: Install server dependencies
+        run: npm ci --prefix server
+
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
         "build:webview": "cd docsui && npm run build",
         "postinstall": "cd client && npm install && cd ../server && npm install && cd ../docsui && npm install && cd ..",
         "bundle:everything": "npm run bundle:format_cli && npm run bundle:antlersls && npm run bundle:prettier",
+        "test": "npm run test:server && npm run test:client",
         "test:server": "npm run compile && mocha ./server/out/test/*.js -- -u tdd",
         "test:grammar": "npm run compile && mocha ./client/out/test/syntax_grammar.test.js -- -u tdd",
         "test:client": "npm run compile && mocha ./client/out/test/*.js -- -u tdd"


### PR DESCRIPTION
## Summary

- run the complete server and client test suites for pull requests and pushes to `main`
- test Node 22 and 24 on Ubuntu and Windows
- use least-privilege permissions, dependency caching, deterministic installs, and cancellation of superseded runs
- provide `npm test` as the canonical local test command

## Verification

- workflow YAML parsed successfully
- clean CI install sequence completed locally
- `npm test` — 394 server tests and 14 client tests passing