### PR TITLE
Update VS Code packages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.1.34",
             "license": "MIT",
             "dependencies": {
+                "@vscode/debugadapter": "^1.68.0",
+                "@vscode/debugprotocol": "^1.68.0",
                 "await-notify": "^1.0.1",
                 "chokidar": "^3.5.2",
                 "file-uri-to-path": "^2.0.0",
@@ -16,7 +18,6 @@
                 "lru-cache": "^4.1.5",
                 "ts-debounce": "^3.0.0",
                 "ts-md5": "^1.2.9",
-                "vscode-debugadapter": "^1.49.0",
                 "vscode-languageclient": "^7.0.0",
                 "vscode-languageserver": "^7.0.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -24,8 +25,7 @@
             },
             "devDependencies": {
                 "@types/vscode": "^1.67.0",
-                "js-yaml": "^4.3.2",
-                "vscode-test": "^1.3.0"
+                "js-yaml": "^4.3.2"
             },
             "engines": {
                 "vscode": "^1.67.0"
@@ -37,22 +37,28 @@
             "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
             "dev": true
         },
+        "node_modules/@vscode/debugadapter": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+            "integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/debugprotocol": "1.68.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@vscode/debugprotocol": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+            "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+            "license": "MIT"
+        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
-        "node_modules/agent-base": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-            "dev": true,
-            "dependencies": {
-                "es6-promisify": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/anymatch": {
             "version": "3.1.2",
@@ -151,15 +157,6 @@
                 "proto-list": "~1.2.1"
             }
         },
-        "node_modules/debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
         "node_modules/editorconfig": {
             "version": "0.15.3",
             "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
@@ -181,21 +178,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
-            }
-        },
-        "node_modules/es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "node_modules/es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "dependencies": {
-                "es6-promise": "^4.0.3"
             }
         },
         "node_modules/file-uri-to-path": {
@@ -264,32 +246,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/inflight": {
@@ -425,12 +381,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
-        },
         "node_modules/nopt": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -502,18 +452,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
         "node_modules/semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -552,22 +490,6 @@
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
             "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
-        },
-        "node_modules/vscode-debugadapter": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.49.0.tgz",
-            "integrity": "sha512-nhes9zaLanFcHuchytOXGsLTGpU5qkz10mC9gVchiwNuX2Bljmc6+wsNbCyE5dOxu6F0pn3f+LEJQGMU1kcnvQ==",
-            "deprecated": "This package has been renamed to @vscode/debugadapter, please update to the new name",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "vscode-debugprotocol": "1.49.0"
-            }
-        },
-        "node_modules/vscode-debugprotocol": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz",
-            "integrity": "sha512-3VkK3BmaqN+BGIq4lavWp9a2IC6VYgkWkkMQm6Sa5ACkhBF6ThJDrkP+/3rFE4G7F8+mM3f4bhhJhhMax2IPfg==",
-            "deprecated": "This package has been renamed to @vscode/debugprotocol, please update to the new name"
         },
         "node_modules/vscode-jsonrpc": {
             "version": "6.0.0",
@@ -620,21 +542,6 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
-        "node_modules/vscode-test": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",
-            "integrity": "sha512-LddukcBiSU2FVTDr3c1D8lwkiOvwlJdDL2hqVbn6gIz+rpTqUCkMZSKYm94Y1v0WXlHSDQBsXyY+tchWQgGVsw==",
-            "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-            "dev": true,
-            "dependencies": {
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.4",
-                "rimraf": "^2.6.3"
-            },
-            "engines": {
-                "node": ">=8.9.3"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -662,19 +569,23 @@
             "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
             "dev": true
         },
+        "@vscode/debugadapter": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+            "integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+            "requires": {
+                "@vscode/debugprotocol": "1.68.0"
+            }
+        },
+        "@vscode/debugprotocol": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+            "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
-        "agent-base": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-            "dev": true,
-            "requires": {
-                "es6-promisify": "^5.0.0"
-            }
         },
         "anymatch": {
             "version": "3.1.2",
@@ -757,15 +668,6 @@
                 "proto-list": "~1.2.1"
             }
         },
-        "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "requires": {
-                "ms": "2.0.0"
-            }
-        },
         "editorconfig": {
             "version": "0.15.3",
             "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
@@ -782,21 +684,6 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
                     "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
                 }
-            }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
-        },
-        "es6-promisify": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "^4.0.3"
             }
         },
         "file-uri-to-path": {
@@ -842,26 +729,6 @@
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "requires": {
                 "is-glob": "^4.0.1"
-            }
-        },
-        "http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-            "dev": true,
-            "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            }
-        },
-        "https-proxy-agent": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-            "dev": true,
-            "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
             }
         },
         "inflight": {
@@ -952,12 +819,6 @@
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
-        "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
-        },
         "nopt": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -1007,15 +868,6 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
-        },
         "semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1043,20 +895,6 @@
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
             "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
-        },
-        "vscode-debugadapter": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.49.0.tgz",
-            "integrity": "sha512-nhes9zaLanFcHuchytOXGsLTGpU5qkz10mC9gVchiwNuX2Bljmc6+wsNbCyE5dOxu6F0pn3f+LEJQGMU1kcnvQ==",
-            "requires": {
-                "mkdirp": "^1.0.4",
-                "vscode-debugprotocol": "1.49.0"
-            }
-        },
-        "vscode-debugprotocol": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz",
-            "integrity": "sha512-3VkK3BmaqN+BGIq4lavWp9a2IC6VYgkWkkMQm6Sa5ACkhBF6ThJDrkP+/3rFE4G7F8+mM3f4bhhJhhMax2IPfg=="
         },
         "vscode-jsonrpc": {
             "version": "6.0.0",
@@ -1099,17 +937,6 @@
             "version": "3.16.0",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-        },
-        "vscode-test": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",
-            "integrity": "sha512-LddukcBiSU2FVTDr3c1D8lwkiOvwlJdDL2hqVbn6gIz+rpTqUCkMZSKYm94Y1v0WXlHSDQBsXyY+tchWQgGVsw==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.4",
-                "rimraf": "^2.6.3"
-            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,8 @@
         ]
     },
     "dependencies": {
+        "@vscode/debugadapter": "^1.68.0",
+        "@vscode/debugprotocol": "^1.68.0",
         "await-notify": "^1.0.1",
         "chokidar": "^3.5.2",
         "file-uri-to-path": "^2.0.0",
@@ -68,7 +70,6 @@
         "lru-cache": "^4.1.5",
         "ts-debounce": "^3.0.0",
         "ts-md5": "^1.2.9",
-        "vscode-debugadapter": "^1.49.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -76,7 +77,6 @@
     },
     "devDependencies": {
         "@types/vscode": "^1.67.0",
-        "js-yaml": "^4.3.2",
-        "vscode-test": "^1.3.0"
+        "js-yaml": "^4.3.2"
     }
 }

--- a/client/src/debug/antlersDebug.ts
+++ b/client/src/debug/antlersDebug.ts
@@ -1,8 +1,8 @@
 
 import {
 	LoggingDebugSession, InitializedEvent, StoppedEvent, Thread, Scope, Handles, Breakpoint
-} from 'vscode-debugadapter';
-import { DebugProtocol } from 'vscode-debugprotocol';
+} from '@vscode/debugadapter';
+import { DebugProtocol } from '@vscode/debugprotocol';
 import { Subject } from 'await-notify';
 import { IRuntimeBreakpoint, IRuntimeException, RuntimeBridge } from './runtimeBridge';
 import * as nodePath from 'path';


### PR DESCRIPTION
Replaces the deprecated vscode-debugadapter and vscode-debugprotocol packages with their official @vscode scoped equivalents. Removes the unused deprecated vscode-test dependency instead of replacing dead test infrastructure. The client audit remains clean and the dependency tree is smaller. Testing: npm test (396 server, 14 client); inline debug adapter runtime initialization smoke test.