### PR TITLE
Update TypeScript

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,12 +24,28 @@
                 "yaml": "^1.10.3"
             },
             "devDependencies": {
+                "@types/mocha": "^10.0.10",
+                "@types/node": "^12.20.55",
                 "@types/vscode": "^1.67.0",
                 "js-yaml": "^4.3.2"
             },
             "engines": {
                 "vscode": "^1.67.0"
             }
+        },
+        "node_modules/@types/mocha": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/vscode": {
             "version": "1.68.0",
@@ -563,6 +579,18 @@
         }
     },
     "dependencies": {
+        "@types/mocha": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true
+        },
         "@types/vscode": {
             "version": "1.68.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,8 @@
         "yaml": "^1.10.3"
     },
     "devDependencies": {
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^12.20.55",
         "@types/vscode": "^1.67.0",
         "js-yaml": "^4.3.2"
     }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,11 @@
 		"outDir": "out",
 		"rootDir": "src",
 		"sourceMap": true,
+		"strict": false,
+		"types": [
+			"mocha",
+			"node"
+		],
 		"skipLibCheck": true
 	},
 	"include": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,10 @@
                 "ts-md5": "^1.3.1"
             },
             "devDependencies": {
-                "@types/mocha": "^8.2.3",
-                "@types/node": "^12.20.55",
                 "esbuild": "^0.28.2",
                 "eslint": "^8.38.0",
                 "mocha": "^10.8.2",
-                "typescript": "^4.9.5",
+                "typescript": "^6.0.3",
                 "vscode-oniguruma": "^2.0.1",
                 "vscode-textmate": "^9.3.2"
             },
@@ -606,18 +604,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/@types/mocha": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
-            "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
-            "dev": true
-        },
-        "node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-            "dev": true
         },
         "node_modules/acorn": {
             "version": "8.8.2",
@@ -2142,16 +2128,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -217,12 +217,10 @@
         "test:client": "npm run compile && mocha ./client/out/test/*.js -- -u tdd"
     },
     "devDependencies": {
-        "@types/mocha": "^8.2.3",
-        "@types/node": "^12.20.55",
         "esbuild": "^0.28.2",
         "eslint": "^8.38.0",
         "mocha": "^10.8.2",
-        "typescript": "^4.9.5",
+        "typescript": "^6.0.3",
         "vscode-oniguruma": "^2.0.1",
         "vscode-textmate": "^9.3.2"
     },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,10 +25,12 @@
             "devDependencies": {
                 "@types/js-beautify": "^1.14.3",
                 "@types/js-yaml": "^4.0.5",
+                "@types/mocha": "^10.0.10",
+                "@types/node": "^12.20.55",
                 "@types/prettier": "^2.6.3",
                 "@types/semver": "^7.3.5",
                 "@typescript-eslint/parser": "^4.29.3",
-                "typescript": "^4.4.2"
+                "typescript": "^6.0.3"
             },
             "engines": {
                 "node": "*"
@@ -294,6 +296,20 @@
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
             "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
             "dev": true
+        },
+        "node_modules/@types/mocha": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/prettier": {
             "version": "2.6.3",
@@ -2052,16 +2068,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/uri-js": {
@@ -2421,6 +2438,18 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
             "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
             "dev": true
         },
         "@types/prettier": {
@@ -3689,9 +3718,9 @@
             "peer": true
         },
         "typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true
         },
         "uri-js": {

--- a/server/package.json
+++ b/server/package.json
@@ -31,9 +31,11 @@
     "devDependencies": {
         "@types/js-beautify": "^1.14.3",
         "@types/js-yaml": "^4.0.5",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^12.20.55",
         "@types/prettier": "^2.6.3",
         "@types/semver": "^7.3.5",
         "@typescript-eslint/parser": "^4.29.3",
-        "typescript": "^4.4.2"
+        "typescript": "^6.0.3"
     }
 }

--- a/server/runtime_tsconfig.json
+++ b/server/runtime_tsconfig.json
@@ -1,16 +1,20 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es2019",
 		"lib": [
 			"ES2019",
 			"ES2020.String"
 		],
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "Node16",
+		"moduleResolution": "Node16",
 		"sourceMap": true,
 		"strict": true,
+		"skipLibCheck": true,
+		"types": [
+			"node"
+		],
 		"outDir": "runtimeout",
-		"rootDir": "src/runtime"
+		"rootDir": "src"
 	},
 	"include": [
 		"src/runtime"

--- a/server/src/antlers/scope/engine.ts
+++ b/server/src/antlers/scope/engine.ts
@@ -233,7 +233,7 @@ export class ScopeEngine {
                         const listReference = currentScope.getList(trimmedRuntimeName);
 
                         if (listReference != null && listReference.values.size > 0) {
-                            const firstListVar = listReference.values.entries().next().value[1] as IScopeVariable;
+                            const firstListVar = listReference.values.values().next().value as IScopeVariable;
 
                             currentNode.scopeVariable = {
                                 dataType: 'array',

--- a/server/src/runtime/analyzers/recursiveParentAnalyzer.ts
+++ b/server/src/runtime/analyzers/recursiveParentAnalyzer.ts
@@ -9,7 +9,7 @@ export class RecursiveParentAnalyzer {
             const node = nodes[i];
 
             if (node instanceof RecursiveNode) {
-                const recursiveContent = '*recursive ' + node.name?.name ?? '' + '*';
+                const recursiveContent = '*recursive ' + node.name?.name;
 
                 if (i - 1 < 0) {
                     node.pushError(AntlersError.makeSyntaxError(

--- a/server/src/runtime/parser/languageParser.ts
+++ b/server/src/runtime/parser/languageParser.ts
@@ -2313,7 +2313,7 @@ export class LanguageParser {
         return newTokens;
     }
 
-    private isOperand(token: AbstractNode) {
+    private isOperand(token: AbstractNode): boolean {
         return token instanceof VariableNode || token instanceof LogicGroup ||
             token instanceof StringValueNode || token instanceof NumberNode ||
             token instanceof FalseConstant || token instanceof NullConstant ||
@@ -2323,7 +2323,7 @@ export class LanguageParser {
             token instanceof ScopeAssignmentOperator;
     }
 
-    private isProperMethodChainTargetStrict(token: AbstractNode) {
+    private isProperMethodChainTargetStrict(token: AbstractNode): boolean {
         return token instanceof LogicGroup ||
             token instanceof StringValueNode || token instanceof NumberNode ||
             token instanceof FalseConstant || token instanceof NullConstant ||

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,11 +5,15 @@
 			"ES2020",
 			"ES2020.String"
 		],
-		"module": "ESNext",
-		"moduleResolution": "node",
+		"module": "Node16",
+		"moduleResolution": "Node16",
         "esModuleInterop": true,
 		"sourceMap": true,
 		"strict": true,
+		"types": [
+			"mocha",
+			"node"
+		],
 		"outDir": "out",
 		"rootDir": "src",
         "declaration": true,


### PR DESCRIPTION
## Summary

- update the root and server compilers to TypeScript 6
- use Node16 module resolution and preserve the client's existing non-strict contract explicitly
- declare Mocha and Node test types in the packages that use them
- address TypeScript 6 control-flow checks without changing parser behavior
- refresh the standalone runtime compiler configuration

## Verification

- `npm test` (396 server tests, 14 client tests)
- `npx tsc -p server/runtime_tsconfig.json --noEmit`
- compiled language-server initialize handshake
- compiled Prettier plugin idempotence smoke test
- CLI bundle/help smoke test
