### PR TITLE
Update LSP

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,19 +18,17 @@
                 "lru-cache": "^4.1.5",
                 "ts-debounce": "^3.0.0",
                 "ts-md5": "^1.2.9",
-                "vscode-languageclient": "^7.0.0",
-                "vscode-languageserver": "^7.0.0",
-                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageclient": "^10.1.1",
                 "yaml": "^1.10.3"
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.10",
                 "@types/node": "^12.20.55",
-                "@types/vscode": "^1.67.0",
+                "@types/vscode": "^1.91.0",
                 "js-yaml": "^4.3.2"
             },
             "engines": {
-                "vscode": "^1.67.0"
+                "vscode": "^1.91.0"
             }
         },
         "node_modules/@types/mocha": {
@@ -48,10 +46,11 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.68.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
-            "dev": true
+            "version": "1.134.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
+            "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@vscode/debugadapter": {
             "version": "1.68.0",
@@ -507,56 +506,87 @@
             "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
             "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
         },
-        "node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-            "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
-            }
-        },
         "node_modules/vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.1.tgz",
+            "integrity": "sha512-EbwIF+KUbwxD5jumQNpiBCv7BJM3Rierv4hcbw/p5jdsnwFFpR/B2VmwqfH4p5XsK46nkH3ugA3WtwJekHHJEw==",
+            "license": "MIT",
             "dependencies": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "minimatch": "^10.2.6",
+                "semver": "^7.8.1",
+                "vscode-languageserver-protocol": "3.18.3",
+                "vscode-languageserver-textdocument": "1.0.14"
             },
             "engines": {
-                "vscode": "^1.52.0"
+                "vscode": "^1.91.0"
             }
         },
-        "node_modules/vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+        "node_modules/vscode-languageclient/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "license": "MIT",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.16.0"
+                "balanced-match": "^4.0.2"
             },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
+            "engines": {
+                "node": "20 || >=22"
             }
         },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "brace-expansion": "^5.0.8"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+            "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.3.tgz",
+            "integrity": "sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "9.0.2",
+                "vscode-languageserver-types": "3.18.3"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.3.tgz",
+            "integrity": "sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==",
+            "license": "MIT"
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
-            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+            "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+            "license": "MIT"
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
@@ -592,9 +622,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.68.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+            "version": "1.134.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
+            "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
             "dev": true
         },
         "@vscode/debugadapter": {
@@ -924,47 +954,63 @@
             "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
             "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
         },
-        "vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-        },
         "vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.1.tgz",
+            "integrity": "sha512-EbwIF+KUbwxD5jumQNpiBCv7BJM3Rierv4hcbw/p5jdsnwFFpR/B2VmwqfH4p5XsK46nkH3ugA3WtwJekHHJEw==",
             "requires": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
-            }
-        },
-        "vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-            "requires": {
-                "vscode-languageserver-protocol": "3.16.0"
-            }
-        },
-        "vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-            "requires": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "minimatch": "^10.2.6",
+                "semver": "^7.8.1",
+                "vscode-languageserver-protocol": "3.18.3",
+                "vscode-languageserver-textdocument": "1.0.14"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+                    "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+                },
+                "brace-expansion": {
+                    "version": "5.0.9",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+                    "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+                    "requires": {
+                        "balanced-match": "^4.0.2"
+                    }
+                },
+                "minimatch": {
+                    "version": "10.2.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+                    "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+                    "requires": {
+                        "brace-expansion": "^5.0.8"
+                    }
+                },
+                "vscode-jsonrpc": {
+                    "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+                    "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ=="
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.18.3",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.3.tgz",
+                    "integrity": "sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==",
+                    "requires": {
+                        "vscode-jsonrpc": "9.0.2",
+                        "vscode-languageserver-types": "3.18.3"
+                    }
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.18.3",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.3.tgz",
+                    "integrity": "sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw=="
+                }
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
-            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
-        },
-        "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+            "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "version": "0.1.34",
     "publisher": "stillat",
     "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.91.0"
     },
     "repository": {
         "type": "git",
@@ -70,15 +70,13 @@
         "lru-cache": "^4.1.5",
         "ts-debounce": "^3.0.0",
         "ts-md5": "^1.2.9",
-        "vscode-languageclient": "^7.0.0",
-        "vscode-languageserver": "^7.0.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageclient": "^10.1.1",
         "yaml": "^1.10.3"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^12.20.55",
-        "@types/vscode": "^1.67.0",
+        "@types/vscode": "^1.91.0",
         "js-yaml": "^4.3.2"
     }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -94,7 +94,7 @@ function askForProjectUpdate() {
 
 const debounceAskForProjectUpdate = debounce(askForProjectUpdate, 350);
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
         path.join('server', 'out', 'server.js')
@@ -211,46 +211,41 @@ export function activate(context: ExtensionContext) {
     activateAntlersDebug(context);
 
     // Start the client. This will also launch the server
-    const disposable = client.start();
-    toDispose.push(disposable);
-    client.onReady().then(() => {
+    await client.start();
+    isClientReady = true;
 
+    client.onNotification(ProjectUpdatedNotification.type, (f) => {
+        if (projectExplorer != null) {
+            projectExplorer.updateStructure(f.content);
+        }
+    });
 
-        isClientReady = true;
-
-        client.onNotification(ProjectUpdatedNotification.type, (f) => {
-            if (projectExplorer != null) {
-                projectExplorer.updateStructure(f.content);
+    setTimeout(() => {
+        client.sendRequest(SemanticTokenLegendRequest.type).then(legend => {
+            if (legend) {
+                const provider: DocumentSemanticTokensProvider & DocumentRangeSemanticTokensProvider = {
+                    provideDocumentSemanticTokens(doc) {
+                        const params: SemanticTokenParams = {
+                            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
+                        };
+                        return client.sendRequest(SemanticTokenRequest.type, params).then(data => {
+                            return data && new SemanticTokens(new Uint32Array(data));
+                        });
+                    },
+                    provideDocumentRangeSemanticTokens(doc, range) {
+                        const params: SemanticTokenParams = {
+                            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
+                            ranges: [client.code2ProtocolConverter.asRange(range)]
+                        };
+                        return client.sendRequest(SemanticTokenRequest.type, params).then(data => {
+                            return data && new SemanticTokens(new Uint32Array(data));
+                        });
+                    }
+                };
+                toDispose.push(languages.registerDocumentSemanticTokensProvider(documentSelector, provider, new SemanticTokensLegend(legend.types, legend.modifiers)));
             }
         });
-
-        setTimeout(() => {
-            client.sendRequest(SemanticTokenLegendRequest.type).then(legend => {
-                if (legend) {
-                    const provider: DocumentSemanticTokensProvider & DocumentRangeSemanticTokensProvider = {
-                        provideDocumentSemanticTokens(doc) {
-                            const params: SemanticTokenParams = {
-                                textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
-                            };
-                            return client.sendRequest(SemanticTokenRequest.type, params).then(data => {
-                                return data && new SemanticTokens(new Uint32Array(data));
-                            });
-                        },
-                        provideDocumentRangeSemanticTokens(doc, range) {
-                            const params: SemanticTokenParams = {
-                                textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
-                                ranges: [client.code2ProtocolConverter.asRange(range)]
-                            };
-                            return client.sendRequest(SemanticTokenRequest.type, params).then(data => {
-                                return data && new SemanticTokens(new Uint32Array(data));
-                            });
-                        }
-                    };
-                    toDispose.push(languages.registerDocumentSemanticTokensProvider(documentSelector, provider, new SemanticTokensLegend(legend.types, legend.modifiers)));
-                }
-            });
-        }, 2500);
-    });
+    }, 2500);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/project/projectExplorer.ts
+++ b/client/src/project/projectExplorer.ts
@@ -291,8 +291,8 @@ class ProjectItem extends vscode.TreeItem {
         if (typeof context['internalIcon'] === 'string') {
             this.icon = context['internalIcon'] as string;
             this.iconPath = {
-                light: path.join(__dirname, '..', '..', '..', 'resources', 'light', this.icon + '.svg'),
-                dark: path.join(__dirname, '..', '..', '..', 'resources', 'dark', this.icon + '.svg'),
+                light: vscode.Uri.file(path.join(__dirname, '..', '..', '..', 'resources', 'light', this.icon + '.svg')),
+                dark: vscode.Uri.file(path.join(__dirname, '..', '..', '..', 'resources', 'dark', this.icon + '.svg')),
             };
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "vscode-textmate": "^9.3.2"
             },
             "engines": {
-                "vscode": "^1.43.0"
+                "vscode": "^1.91.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "Formatters"
     ],
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.91.0"
     },
     "activationEvents": [
         "onLanguage:html",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,8 +17,10 @@
                 "semver": "^5.7.2",
                 "ts-debounce": "^3.0.0",
                 "ts-md5": "^1.2.9",
-                "vscode-languageserver": "^7.0.0",
-                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver": "^10.1.1",
+                "vscode-languageserver-protocol": "^3.18.3",
+                "vscode-languageserver-textdocument": "^1.0.14",
+                "vscode-languageserver-types": "^3.18.3",
                 "yaml": "^1.10.3",
                 "yargs": "^17.3.1"
             },
@@ -2099,42 +2101,47 @@
             "peer": true
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+            "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.1.tgz",
+            "integrity": "sha512-/cG04Fiq99rEtoDrfPpv0k6NyUFlck5GNtZLQZv1rxkBkc/4FrJNvEKTN5k1Si3O1hRguP++ciYlX9cdjdYxFQ==",
+            "license": "MIT",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.16.0"
+                "vscode-languageserver-protocol": "3.18.3"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.3.tgz",
+            "integrity": "sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==",
+            "license": "MIT",
             "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "9.0.2",
+                "vscode-languageserver-types": "3.18.3"
             }
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
-            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+            "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+            "license": "MIT"
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.3.tgz",
+            "integrity": "sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==",
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -3741,36 +3748,36 @@
             "peer": true
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+            "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ=="
         },
         "vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.1.tgz",
+            "integrity": "sha512-/cG04Fiq99rEtoDrfPpv0k6NyUFlck5GNtZLQZv1rxkBkc/4FrJNvEKTN5k1Si3O1hRguP++ciYlX9cdjdYxFQ==",
             "requires": {
-                "vscode-languageserver-protocol": "3.16.0"
+                "vscode-languageserver-protocol": "3.18.3"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.3.tgz",
+            "integrity": "sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "9.0.2",
+                "vscode-languageserver-types": "3.18.3"
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
-            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+            "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ=="
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.18.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.3.tgz",
+            "integrity": "sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw=="
         },
         "which": {
             "version": "2.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -22,8 +22,10 @@
         "semver": "^5.7.2",
         "ts-debounce": "^3.0.0",
         "ts-md5": "^1.2.9",
-        "vscode-languageserver": "^7.0.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver": "^10.1.1",
+        "vscode-languageserver-protocol": "^3.18.3",
+        "vscode-languageserver-textdocument": "^1.0.14",
+        "vscode-languageserver-types": "^3.18.3",
         "yaml": "^1.10.3",
         "yargs": "^17.3.1"
     },

--- a/server/src/protocol/projectDetailsNotification.ts
+++ b/server/src/protocol/projectDetailsNotification.ts
@@ -1,4 +1,4 @@
-import { NotificationType } from "vscode-languageserver/node.js";
+import { NotificationType } from "vscode-languageserver/node";
 import { IProjectFields } from "../projects/structuredFieldTypes/types.js";
 
 export interface ProjectDetailsParams {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,7 +20,7 @@ import {
     TextDocuments,
     TextDocumentSyncKind,
     WorkspaceEdit,
-} from "vscode-languageserver/node.js";
+} from "vscode-languageserver/node";
 import {
     handleOnCompletion,
     handleOnCompletionResolve,

--- a/server/src/services/antlersFoldingRegions.ts
+++ b/server/src/services/antlersFoldingRegions.ts
@@ -1,8 +1,8 @@
 import {
     FoldingRange,
+    FoldingRangeKind,
     FoldingRangeParams,
 } from "vscode-languageserver-protocol";
-import { FoldingRangeKind } from 'vscode-languageserver-protocol/lib/common/protocol.foldingRange.js';
 import { sessionDocuments } from '../languageService/documents.js';
 import {
     multilineCommentToFoldingRange,

--- a/server/src/services/modifierMethodSignatures.ts
+++ b/server/src/services/modifierMethodSignatures.ts
@@ -9,8 +9,6 @@ import { IModifier } from '../antlers/modifierTypes.js';
 import { makeProviderRequest } from "../providers/providerParameters.js";
 
 const EmptySignatureHelp: SignatureHelp = {
-    activeSignature: null,
-    activeParameter: null,
     signatures: [],
 };
 

--- a/server/src/test/project_details_notification.test.ts
+++ b/server/src/test/project_details_notification.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { NotificationType } from "vscode-languageserver/node.js";
+import { NotificationType } from "vscode-languageserver/node";
 import {
     notifyProjectDetails,
     ProjectDetailsAvailableNotification,


### PR DESCRIPTION
## Summary

- update the language client and server to 10.1.1
- update protocol/types to 3.18.3 and text documents to 1.0.14
- raise the minimum VS Code version to 1.91
- adapt extension activation to the asynchronous client startup API
- use package-export-safe LSP imports and current protocol value types
- remove unused server dependencies from the client package
- declare directly imported protocol packages in the server package

## Verification

- `npm test` (396 server tests, 14 client tests)
- compiled ESM language-server initialize handshake
- bundled CJS language-server initialize handshake
- client, server, and production dependency audits report zero vulnerabilities
