### PR TITLE
Prepare 2.7.0

### DIFF
--- a/antlersls/package-lock.json
+++ b/antlersls/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "antlers-language-server",
-  "version": "1.0.6",
+  "version": "1.3.15",
   "lockfileVersion": 1
 }

--- a/antlersls/package.json
+++ b/antlersls/package.json
@@ -1,6 +1,6 @@
 {
     "name": "antlers-language-server",
-    "version": "1.3.14",
+    "version": "1.3.15",
     "description": "The Antlers language server.",
     "main": "server.js",
     "bin": {

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,45 @@
 
 Bugs fixed, what's new, and more! :)
 
+## 2.7.0
+
+This is a large formatter, language support, stability, and project health release.
+
+- Requires Visual Studio Code 1.91 or newer.
+
+### Formatting
+
+- Adds `preserve` and `collapse` array wrapping modes across VS Code, Prettier, and the formatter CLI. Multi-line arrays are preserved by default, while single-line arrays remain inline. (#118, #117, #83)
+- Normalizes preserved array indentation across nested arrays, surrounding indentation levels, configured space widths, and tabs without introducing formatting drift. (#129)
+- Preserves trailing content after nested interpolation, triple fallback operators, shorthand variable parameters, quoted modifier values, automatic statement boundaries, and relative comment indentation. (#119, #116, #115, #100, #99, #98)
+- Improves nested switch formatting, including switches inside long HTML attributes and nested function arguments. (#125, #81)
+- Improves formatter parity with current Antlers syntax, including shorthand arrays, array accessors, arrow/dot/colon method chains, escaped braces, and authored escape sequences. (#127)
+- Formats embedded PHP consistently through VS Code, Prettier, and the formatter CLI, with stable indentation for spaces and tabs while preserving invalid PHP and multiline string contents. (#128, #86)
+
+### Language support and editor experience
+
+- Adds current Statamic core tags and explicit methods to completions, diagnostics, scopes, and highlighting. (#126)
+- Adds completion parity for Antlers components using `s-`, `s:`, `statamic-`, and `statamic:` syntax, including parameter names, project-backed values, and bound scope variables. (#126)
+- Adds completion and highlighting support for `@props`, `@aware`, and `@cascade` directives. (#126)
+- Improves syntax highlighting between HTML attributes, inside modifier strings, around conditional attributes, for dynamic HTML tags, and within Alpine attributes. (#124, #93, #91, #105)
+- Reports invalid `{{ else if ... }}` syntax and suggests the supported `elseif` spelling. (#121, #109)
+- Resolves document links for quoted `partial src=...` parameters while preserving method-style partial links. (#122, #103)
+- Applies the HTML comment override setting reliably when the extension activates and when active editors or resource-scoped settings change. (#123, #107)
+
+### Stability
+
+- Hardens project scanning against directory symlinks, broken entries, inaccessible paths, and incorrectly unfiltered direct scans. (#120, #110)
+- Publishes project details as an LSP notification so non-VS Code clients no longer need to implement a private request to avoid a server crash. (#130, #59)
+
+### Project health
+
+- Adds the full server and client test suite to GitHub Actions across Windows and Ubuntu on Node.js 22 and 24. (#131)
+- Removes the legacy documentation webview and its separate frontend build. (#132)
+- Updates vulnerable runtime dependencies and refreshes the dependency tree. (#133)
+- Updates esbuild, adopts the official scoped VS Code debug packages, and removes unused deprecated VS Code test infrastructure. (#134, #135)
+- Updates the project to TypeScript 6 and Node16 module resolution. (#136)
+- Updates the language client and server to 10.1.1, the Language Server Protocol packages to 3.18.3, and the minimum supported VS Code version to 1.91. (#137)
+
 ## 2.6.22
 
 - Rebuild (correct issue with reloading project details) (#106)

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "antlers-statamic",
-    "version": "0.1.34",
+    "version": "0.1.35",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "antlers-statamic",
-            "version": "0.1.34",
+            "version": "0.1.35",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "0.1.34",
+    "version": "0.1.35",
     "publisher": "stillat",
     "engines": {
         "vscode": "^1.91.0"

--- a/formatcli/package/package-lock.json
+++ b/formatcli/package/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "antlers-formatter",
-  "version": "1.0.5",
+  "version": "1.2.15",
   "lockfileVersion": 1
 }

--- a/formatcli/package/package.json
+++ b/formatcli/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "antlers-formatter",
-    "version": "1.2.14",
+    "version": "1.2.15",
     "description": "Formats Antlers template files.",
     "main": "cli.js",
     "bin": {

--- a/formatcli/prettier-plugin-antlers/package.json
+++ b/formatcli/prettier-plugin-antlers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-antlers",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Antlers Prettier plugin.",
     "type": "module",
     "main": "plugin.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-antlers",
-    "version": "2.6.22",
+    "version": "2.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-antlers",
-            "version": "2.6.22",
+            "version": "2.7.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "2.6.22",
+    "version": "2.7.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/Stillat/vscode-antlers-language-server"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stillat-antlers-lsp",
-    "version": "1.2.19",
+    "version": "1.2.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "stillat-antlers-lsp",
-            "version": "1.2.19",
+            "version": "1.2.20",
             "license": "MIT",
             "dependencies": {
                 "@prettier/plugin-php": "^0.22",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stillat-antlers-lsp",
     "description": "Language server for Antlers.",
-    "version": "1.2.19",
+    "version": "1.2.20",
     "author": "John Koster",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
Prepares the 2.7.0 release with consolidated changelog notes for PRs #118 through #137 and synchronized versions for the extension, client, server, Prettier plugin, formatter CLI, and standalone language server. Validation: npm test (410 passing), dry-run package builds for all six publishable packages, and an exact manifest/lock version audit.