### PR TITLE
Harden the VS Code debug runtime lifecycle

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",
                 "@vscode/debugprotocol": "^1.68.0",
-                "await-notify": "^1.0.1",
                 "chokidar": "^3.5.2",
                 "file-uri-to-path": "^2.0.0",
                 "js-beautify": "^1.13.13",
@@ -92,11 +91,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "node_modules/await-notify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-            "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
         },
         "node_modules/balanced-match": {
             "version": "1.0.0",
@@ -659,11 +653,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "await-notify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-            "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
         },
         "balanced-match": {
             "version": "1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -63,7 +63,6 @@
     "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",
-        "await-notify": "^1.0.1",
         "chokidar": "^3.5.2",
         "file-uri-to-path": "^2.0.0",
         "js-beautify": "^1.13.13",

--- a/client/src/debug/antlersDebug.ts
+++ b/client/src/debug/antlersDebug.ts
@@ -118,9 +118,9 @@ export class AntlersDebugSession extends LoggingDebugSession {
 		response.body.supportsSteppingGranularity = false;
 
 
+		this._runtimeBridge.startSession();
 		this.sendResponse(response);
 		this.sendEvent(new InitializedEvent());
-		this._runtimeBridge.startSession();
 	}
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {

--- a/client/src/debug/antlersDebug.ts
+++ b/client/src/debug/antlersDebug.ts
@@ -3,7 +3,6 @@ import {
 	LoggingDebugSession, InitializedEvent, StoppedEvent, Thread, Scope, Handles, Breakpoint
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
-import { Subject } from 'await-notify';
 import { IRuntimeBreakpoint, IRuntimeException, RuntimeBridge } from './runtimeBridge';
 import * as nodePath from 'path';
 
@@ -33,8 +32,7 @@ export {ActiveTimings};
 export class AntlersDebugSession extends LoggingDebugSession {
 	public static threadID = 1;
 	
-	private _configurationDone = new Subject();
-	private _runtimeBridge:RuntimeBridge = null;
+	private _runtimeBridge:RuntimeBridge;
 	private _lastMemDump:any = null;
 	private _hitBreakpoint:IRuntimeBreakpoint| null = null;
 	private _variableHandles = new Handles<'root' | 'contextual' | 'other'>();
@@ -57,8 +55,8 @@ export class AntlersDebugSession extends LoggingDebugSession {
 		});
 	}
 
-	public shutdown() {
-		this._runtimeBridge.stopSession();
+	public shutdown(): void {
+		void this._runtimeBridge.stopSession().finally(() => super.shutdown());
 	}
 
 	private objToArray(object:any) {
@@ -113,9 +111,11 @@ export class AntlersDebugSession extends LoggingDebugSession {
 		response.body.supportsSetExpression = false;
 		response.body.supportsWriteMemoryRequest = false;
 
-		// make VS Code send disassemble request
-		response.body.supportsDisassembleRequest = true;
-		response.body.supportsSteppingGranularity = true;
+		// Antlers debugging is driven by the Statamic runtime bridge. It can
+		// continue from a breakpoint, but it does not expose instructions or
+		// instruction-level stepping. Do not advertise requests we cannot serve.
+		response.body.supportsDisassembleRequest = false;
+		response.body.supportsSteppingGranularity = false;
 
 
 		this.sendResponse(response);
@@ -125,13 +125,9 @@ export class AntlersDebugSession extends LoggingDebugSession {
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
 		super.configurationDoneRequest(response, args);
-
-		// notify the launchRequest that configuration has finished
-		this._configurationDone.notify();
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: DebugProtocol.LaunchRequestArguments) {
-
 		response.success = true;
 		this.sendResponse(response);
 	}
@@ -150,15 +146,12 @@ export class AntlersDebugSession extends LoggingDebugSession {
 	}
 
 	protected variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments, request?: DebugProtocol.Request) {
+		response.body = { variables: [] };
+
 		if (!this._variableHandles || !this._lastMemDump) {
 			this.sendResponse(response);
 			return;
 		}
-
-		response.body = {
-			variables: [
-			]
-		};
 
 		const varHandle = this._variableHandles.get(args.variablesReference);
 
@@ -180,6 +173,8 @@ export class AntlersDebugSession extends LoggingDebugSession {
 	}
 
 	protected breakpointLocationsRequest(response: DebugProtocol.BreakpointLocationsResponse, args: DebugProtocol.BreakpointLocationsArguments, request?: DebugProtocol.Request) {
+		response.body = { breakpoints: [] };
+
 		if (args.source.path) {
 			const bps = this._runtimeBridge.getAllBreakPoints(args.source.path, args.line);
 
@@ -214,6 +209,11 @@ export class AntlersDebugSession extends LoggingDebugSession {
 	}
 
 	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) {
+		response.body = {
+			stackFrames: [],
+			totalFrames: 0
+		};
+
 		if (this._lastException != null) {
 			response.body  = {
 				stackFrames: [
@@ -267,19 +267,27 @@ export class AntlersDebugSession extends LoggingDebugSession {
 	}
 
 	protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) {
-		this._runtimeBridge.releaseActiveLock();
+		this._runtimeBridge?.releaseActiveLock();
+		response.body = { allThreadsContinued: true };
 		
 		this.sendResponse(response);
 	}
 
 	protected async setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): Promise<void> {
-		const path = args.source.path as string,
+		const sourcePath = args.source.path;
+
+		if (sourcePath == null || sourcePath.trim().length === 0) {
+			this.sendErrorResponse(response, 1005, 'An Antlers breakpoint source path is required.');
+			return;
+		}
+
+		const path = nodePath.resolve(sourcePath),
 			clientLines = args.lines || [];
 		
 		this._runtimeBridge.resetBreakPoints(path);
 
 		const breakPoints = clientLines.map(l => {
-			const runtimeBp =  this._runtimeBridge.setBreakPoint(path, l);
+			const runtimeBp = this._runtimeBridge.setBreakPoint(path, l);
 			const bp = new Breakpoint(runtimeBp.verified, runtimeBp.line) as DebugProtocol.Breakpoint;
 			bp.id  = runtimeBp.id;
 

--- a/client/src/debug/runtimeBridge.ts
+++ b/client/src/debug/runtimeBridge.ts
@@ -35,6 +35,7 @@ export class RuntimeBridge extends EventEmitter {
 	private breakpointId = 1;
 	private _activeLock = '';
 	private _keepAliveInterval:NodeJS.Timeout|null = null;
+	private _watchers:chokdar.FSWatcher[] = [];
 	private registeredBreakpoints:Map<string, Map<number, IRuntimeBreakpoint>> = new Map();
 
 	constructor(root: string, resourceRoot: string) {
@@ -52,22 +53,61 @@ export class RuntimeBridge extends EventEmitter {
 	}
 
 	protected startKeepAlive() {
+		if (this._keepAliveInterval != null) {
+			return;
+		}
+
+		this.writeKeepAlive();
 		this._keepAliveInterval = setInterval(function () {
-			fs.writeFileSync(this._antlersDebugKeepAliveFile, (new Date()).valueOf().toString());
+			this.writeKeepAlive();
 		}.bind(this), 2000);
 	}
 
 	protected shutdownKeepAlive() {
 		if (this._keepAliveInterval) {
 			clearInterval(this._keepAliveInterval);
+			this._keepAliveInterval = null;
+		}
+
+		try {
+			if (fs.existsSync(this._antlersDebugKeepAliveFile)) {
+				fs.unlinkSync(this._antlersDebugKeepAliveFile);
+			}
+		} catch (error) {
+			console.error(error);
 		}
 	}
 
-	stopSession() {
+	private writeKeepAlive() {
+		try {
+			fs.writeFileSync(
+				this._antlersDebugKeepAliveFile,
+				(new Date()).valueOf().toString()
+			);
+		} catch (error) {
+			console.error(error);
+		}
+	}
+
+	async stopSession():Promise<void> {
 		this.shutdownKeepAlive();
+		this.releaseActiveLock();
+		resetTimings();
+
+		const watcherShutdown = this._watchers.map((watcher) => watcher.close());
+		this._watchers = [];
+		await Promise.all(watcherShutdown);
+		this.removeAllListeners();
 	}
 
 	startSession() {
+		if (!this._canBoot) {
+			throw new Error(
+				'Unable to initialize the Antlers debugger. The Statamic storage directory was not found.'
+			);
+		}
+
+		this.startWatchers();
 		this.startKeepAlive();
 	}
 
@@ -157,76 +197,77 @@ export class RuntimeBridge extends EventEmitter {
 
 	public releaseActiveLock() {
 		if (this._activeLock != '') {
-			if (fs.existsSync(this._activeLock)) {
-				fs.unlinkSync(this._activeLock);
+			try {
+				if (fs.existsSync(this._activeLock)) {
+					fs.unlinkSync(this._activeLock);
+				}
+			} finally {
+				this._activeLock = '';
 			}
 		}
 	}
 
-	private prepareDebugEnvironment() {
-		if (fs.existsSync(this._debugRoot)) {
-			if (!fs.existsSync(this._antlersDirectory)) {
-				fs.mkdirSync(this._antlersDirectory);
-				fs.mkdirSync(this._antlersDebugDirectory);
-			} else {
-				if (!fs.existsSync(this._antlersDebugDirectory)) {
-					fs.mkdirSync(this._antlersDebugDirectory);
-				}
+	private startWatchers() {
+		if (this._watchers.length > 0) {
+			return;
+		}
+		const watcherOptions:chokdar.WatchOptions = {
+			ignoreInitial: true,
+			awaitWriteFinish: {
+				stabilityThreshold: 50,
+				pollInterval: 10
 			}
+		};
 
-			if (!fs.existsSync(this._antlersDebugBreakpointRegistry)) {
-				fs.mkdirSync(this._antlersDebugBreakpointRegistry);
-			}
-
-			if (!fs.existsSync(this._antlersDebugBreakpointLocks)) {
-				fs.mkdirSync(this._antlersDebugBreakpointLocks);
-			}
-
-			const timingsFile = path.join(this._antlersDebugDirectory, 'timings');
-
-			if (fs.existsSync(timingsFile)) {
-				fs.unlinkSync(timingsFile);
-			}
-
-			chokdar.watch(this._antlersDebugDirectory).on('all', function (event, filePath) {
-				if (filePath.endsWith('timings')) {
-					if (event == 'unlink') {
-						resetTimings();
-					} else {
-						try {
-							if (fs.lstatSync(filePath).isDirectory() === false) {
-								const runtimeTimings = JSON.parse(fs.readFileSync(filePath).toString()) as TimingInterface[];
-								setTimings(runtimeTimings);
-							}
-						} catch (err) {
-							console.error(err);
+		const eventWatcher = chokdar.watch(
+			[
+				path.join(this._antlersDebugDirectory, 'timings'),
+				path.join(this._antlersDebugDirectory, 'exception')
+			],
+			watcherOptions
+		).on('all', function (event, filePath) {
+			if (filePath.endsWith('timings')) {
+				if (event == 'unlink') {
+					resetTimings();
+				} else {
+					try {
+						if (fs.lstatSync(filePath).isDirectory() === false) {
+							const runtimeTimings = JSON.parse(fs.readFileSync(filePath).toString()) as TimingInterface[];
+							setTimings(runtimeTimings);
 						}
-					}
-				} else if (filePath.endsWith('exception')) {
-					if (event != 'unlink') {
-						try {
-							if (fs.lstatSync(filePath).isDirectory() === false) {
-								const runtimeException = JSON.parse(fs.readFileSync(filePath).toString()) as IRuntimeException;
-
-								fs.unlinkSync(filePath);
-								this.sendEvent('runtimeException', runtimeException);
-							}
-						} catch (err) {
-							if (fs.existsSync(filePath)) {
-								fs.unlinkSync(filePath);
-							}
-							console.error(err);
-						}
+					} catch (err) {
+						console.error(err);
 					}
 				}
-			}.bind(this));
+			} else if (filePath.endsWith('exception')) {
+				if (event != 'unlink') {
+					try {
+						if (fs.lstatSync(filePath).isDirectory() === false) {
+							const runtimeException = JSON.parse(fs.readFileSync(filePath).toString()) as IRuntimeException;
 
-			chokdar.watch(this._antlersDebugBreakpointLocks).on('all', function (event, lockPath) {
-				if (event === 'add') {
-					const fileName = path.basename(lockPath),
-						parts = fileName.split('_');
+							fs.unlinkSync(filePath);
+							this.sendEvent('runtimeException', runtimeException);
+						}
+					} catch (err) {
+						if (fs.existsSync(filePath)) {
+							fs.unlinkSync(filePath);
+						}
+						console.error(err);
+					}
+				}
+			}
+		}.bind(this));
 
-					if (parts.length == 2) {
+		const breakpointWatcher = chokdar.watch(
+			this._antlersDebugBreakpointLocks,
+			watcherOptions
+		).on('all', function (event, lockPath) {
+			if (event === 'add') {
+				const fileName = path.basename(lockPath),
+					parts = fileName.split('_');
+
+				if (parts.length == 2) {
+					try {
 						const runtimeSlug = parts[0],
 							lineNumber = parseInt(parts[1]);
 						
@@ -243,14 +284,37 @@ export class RuntimeBridge extends EventEmitter {
 								}
 							}
 						}
+					} catch (error) {
+						// A malformed/partial lock must never leave the PHP request
+						// blocked indefinitely.
+						if (fs.existsSync(lockPath)) {
+							fs.unlinkSync(lockPath);
+						}
+						console.error(error);
 					}
 				}
-			}.bind(this));
+			}
+		}.bind(this));
 
-			return true;
+		this._watchers.push(eventWatcher, breakpointWatcher);
+	}
+
+	private prepareDebugEnvironment() {
+		if (!fs.existsSync(this._debugRoot)) {
+			return false;
 		}
 
-		return false;
+		fs.mkdirSync(this._antlersDebugDirectory, { recursive: true });
+		fs.mkdirSync(this._antlersDebugBreakpointRegistry, { recursive: true });
+		fs.mkdirSync(this._antlersDebugBreakpointLocks, { recursive: true });
+
+		const timingsFile = path.join(this._antlersDebugDirectory, 'timings');
+
+		if (fs.existsSync(timingsFile)) {
+			fs.unlinkSync(timingsFile);
+		}
+
+		return true;
 	}
 
 	private sendEvent(event: string, ... args: any[]): void {

--- a/client/src/test/runtime_bridge.test.ts
+++ b/client/src/test/runtime_bridge.test.ts
@@ -1,0 +1,72 @@
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { RuntimeBridge } from '../debug/runtimeBridge';
+
+function removeDirectory(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            removeDirectory(entryPath);
+        } else {
+            fs.unlinkSync(entryPath);
+        }
+    }
+
+    fs.rmdirSync(directory);
+}
+
+suite('Antlers Debug Runtime Bridge', () => {
+    let temporaryRoot = '';
+
+    setup(() => {
+        temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'antlers-dap-'));
+    });
+
+    teardown(() => {
+        if (temporaryRoot.length > 0 && fs.existsSync(temporaryRoot)) {
+            removeDirectory(temporaryRoot);
+        }
+    });
+
+    test('it owns and cleans up its session resources', async () => {
+        const storageRoot = path.join(temporaryRoot, 'storage');
+        const resourceRoot = path.join(temporaryRoot, 'resources');
+        const templatePath = path.join(
+            resourceRoot,
+            'views',
+            'example.antlers.html'
+        );
+        fs.mkdirSync(storageRoot, { recursive: true });
+
+        const bridge = new RuntimeBridge(storageRoot + path.sep, resourceRoot);
+        bridge.startSession();
+
+        const keepAlivePath = path.join(
+            storageRoot,
+            'antlers',
+            '_debug',
+            'debug-session'
+        );
+        assert.strictEqual(fs.existsSync(keepAlivePath), true);
+        assert.strictEqual(bridge.setBreakPoint(templatePath, 12).verified, true);
+
+        await bridge.stopSession();
+
+        assert.strictEqual(fs.existsSync(keepAlivePath), false);
+    });
+
+    test('it refuses to start outside a Statamic storage directory', () => {
+        const bridge = new RuntimeBridge(
+            path.join(temporaryRoot, 'missing-storage') + path.sep,
+            path.join(temporaryRoot, 'resources')
+        );
+
+        assert.throws(
+            () => bridge.startSession(),
+            /storage directory was not found/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- owns and closes filesystem watchers, keepalive state, active locks, and listeners per debug session
- fails initialization clearly when Statamic debug storage is unavailable, before announcing DAP success
- stops advertising unsupported instruction-level debugging capabilities
- returns valid empty DAP response bodies and removes the unused await-notify dependency

## Validation

- npm test: 396 server tests and 16 client tests pass
- includes focused runtime lifecycle and invalid-project tests