### PR TITLE
Add standard LSP range formatting

### DIFF
--- a/server/src/formatting/formatter.ts
+++ b/server/src/formatting/formatter.ts
@@ -1,4 +1,4 @@
-import { DocumentFormattingParams, Position, } from "vscode-languageserver-protocol";
+import { DocumentFormattingParams, DocumentRangeFormattingParams, Position, } from "vscode-languageserver-protocol";
 import { Range, TextDocument, TextEdit, } from "vscode-languageserver-textdocument";
 import { documentMap, sessionDocuments } from '../languageService/documents.js';
 import { htmlFormatterSettings } from '../languageService/htmlFormatterSettings.js';
@@ -7,6 +7,7 @@ import { getAntlersSettings } from '../server.js';
 import { AntlersFormattingOptions } from './antlersFormattingOptions.js';
 import { BeautifyDocumentFormatter } from './beautifyDocumentFormatter.js';
 import { IHTMLFormatConfiguration } from "./htmlCompat.js";
+import { commonIndent, completeLineRange, reindentFormattedRange } from "./rangeFormatting.js";
 
 export async function formatAntlersDocument(params: DocumentFormattingParams): Promise<TextEdit[] | null> {
     const settings = getAntlersSettings();
@@ -55,4 +56,54 @@ export async function formatAntlersDocument(params: DocumentFormattingParams): P
     }
 
     return null;
+}
+
+export async function formatAntlersRange(
+    params: DocumentRangeFormattingParams
+): Promise<TextEdit[] | null> {
+    const settings = getAntlersSettings();
+    const documentPath = decodeURIComponent(params.textDocument.uri);
+
+    if (settings.formatterIgnoreExtensions.some((extension) =>
+        documentPath.toLowerCase().endsWith(extension.toLowerCase())
+    )) {
+        return null;
+    }
+
+    if (!documentMap.has(documentPath)) {
+        return null;
+    }
+
+    const document = documentMap.get(documentPath) as TextDocument;
+    const range = completeLineRange(document, params.range);
+    const source = document.getText(range);
+
+    if (source.trim().length === 0) {
+        return [];
+    }
+
+    const indent = commonIndent(source);
+    const dedented = source
+        .split(/\r?\n/)
+        .map((line) => line.startsWith(indent) ? line.slice(indent.length) : line)
+        .join("\n");
+    const options = htmlFormatterSettings.format as IHTMLFormatConfiguration;
+    const formatter = new BeautifyDocumentFormatter({
+        htmlOptions: options,
+        formatFrontMatter: false,
+        insertSpaces: params.options.insertSpaces,
+        tabSize: params.options.tabSize,
+        maxStatementsPerLine: 3,
+        formatExtensions: [],
+        arrayWrap: settings.formatterArrayWrap
+    });
+    const formatted = await formatter.formatDocumentAsync(
+        AntlersDocument.fromText(dedented),
+        settings
+    );
+
+    return [{
+        range,
+        newText: reindentFormattedRange(source, formatted)
+    }];
 }

--- a/server/src/formatting/rangeFormatting.ts
+++ b/server/src/formatting/rangeFormatting.ts
@@ -1,0 +1,51 @@
+import { Position } from "vscode-languageserver-protocol";
+import { Range, TextDocument } from "vscode-languageserver-textdocument";
+
+export function completeLineRange(document: TextDocument, requestedRange: Range): Range {
+    const start = Position.create(requestedRange.start.line, 0);
+    let end = requestedRange.end;
+
+    if (end.character > 0) {
+        const nextLineOffset = document.offsetAt(Position.create(end.line + 1, 0));
+        end = document.positionAt(nextLineOffset);
+    }
+
+    return { start, end };
+}
+
+export function commonIndent(text: string): string {
+    const indents = text
+        .split(/\r?\n/)
+        .filter((line) => line.trim().length > 0)
+        .map((line) => /^[\t ]*/.exec(line)?.[0] ?? "");
+
+    if (indents.length === 0) {
+        return "";
+    }
+
+    let prefix = indents[0];
+
+    for (const indent of indents.slice(1)) {
+        while (!indent.startsWith(prefix) && prefix.length > 0) {
+            prefix = prefix.slice(0, -1);
+        }
+    }
+
+    return prefix;
+}
+
+export function reindentFormattedRange(source: string, formatted: string): string {
+    const indent = commonIndent(source);
+    const hadTrailingNewline = /\r?\n$/.test(source);
+    const dedentedResult = formatted.trimEnd();
+    let result = dedentedResult
+        .split("\n")
+        .map((line) => line.length > 0 ? indent + line : line)
+        .join("\n");
+
+    if (hadTrailingNewline) {
+        result += "\n";
+    }
+
+    return result;
+}

--- a/server/src/formatting/rangeFormatting.ts
+++ b/server/src/formatting/rangeFormatting.ts
@@ -36,15 +36,16 @@ export function commonIndent(text: string): string {
 
 export function reindentFormattedRange(source: string, formatted: string): string {
     const indent = commonIndent(source);
+    const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
     const hadTrailingNewline = /\r?\n$/.test(source);
     const dedentedResult = formatted.trimEnd();
     let result = dedentedResult
-        .split("\n")
+        .split(/\r?\n/)
         .map((line) => line.length > 0 ? indent + line : line)
-        .join("\n");
+        .join(lineEnding);
 
     if (hadTrailingNewline) {
-        result += "\n";
+        result += lineEnding;
     }
 
     return result;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -32,7 +32,7 @@ import {
     sendAllDiagnostics,
     validateTextDocument,
 } from "./services/antlersDiagnostics.js";
-import { formatAntlersDocument } from "./formatting/formatter.js";
+import { formatAntlersDocument, formatAntlersRange } from "./formatting/formatter.js";
 import { handleSignatureHelpRequest } from "./services/modifierMethodSignatures.js";
 import { handleDocumentHover } from "./services/antlersHover.js";
 import { handleDefinitionRequest } from "./services/antlersDefinitions.js";
@@ -186,6 +186,7 @@ connection.onInitialize((params: InitializeParams) => {
                 triggerCharacters: [":", '"', "'", "{", "/", "|", "@", ' '],
             },
             documentFormattingProvider: {},
+            documentRangeFormattingProvider: {},
             foldingRangeProvider: {},
             signatureHelpProvider: {
                 triggerCharacters: [','],
@@ -344,6 +345,7 @@ connection.onDefinition(handleDefinitionRequest);
 connection.onFoldingRanges(handleFoldingRequest);
 connection.onSignatureHelp(handleSignatureHelpRequest);
 connection.onDocumentFormatting(formatAntlersDocument);
+connection.onDocumentRangeFormatting(formatAntlersRange);
 connection.onCompletion(debouncedCompletionHandler);
 connection.onCompletionResolve(handleOnCompletionResolve);
 documents.listen(connection);

--- a/server/src/test/range_formatter.test.ts
+++ b/server/src/test/range_formatter.test.ts
@@ -18,4 +18,14 @@ suite("Range Formatter", () => {
             "  {{ title }}"
         );
     });
+
+    test("it preserves CRLF line endings", () => {
+        const source = "    <div>\r\n        {{ title }}\r\n    </div>\r\n";
+        const formatted = "<div>\n    {{ title }}\n</div>\n";
+
+        assert.strictEqual(
+            reindentFormattedRange(source, formatted),
+            "    <div>\r\n        {{ title }}\r\n    </div>\r\n"
+        );
+    });
 });

--- a/server/src/test/range_formatter.test.ts
+++ b/server/src/test/range_formatter.test.ts
@@ -1,0 +1,21 @@
+import assert from "assert";
+import { reindentFormattedRange } from "../formatting/rangeFormatting.js";
+
+suite("Range Formatter", () => {
+    test("it restores the selection's surrounding indentation", () => {
+        const source = "    <div>\n        {{ title }}\n    </div>\n";
+        const formatted = "<div>\n    {{ title }}\n</div>";
+
+        assert.strictEqual(
+            reindentFormattedRange(source, formatted),
+            "    <div>\n        {{ title }}\n    </div>\n"
+        );
+    });
+
+    test("it does not add a trailing newline to an inline selection", () => {
+        assert.strictEqual(
+            reindentFormattedRange("  {{ title }}", "{{ title }}\n"),
+            "  {{ title }}"
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- advertises and handles textDocument/rangeFormatting
- expands selections to complete lines before formatting
- preserves surrounding indentation, CRLF/LF line endings, and existing trailing-newline behavior
- respects formatter ignore settings and editor indentation options

## Validation

- npm test: 399 server tests and 14 client tests pass
- includes focused indentation, inline-selection, and CRLF coverage
- generated npm bundles are intentionally deferred to the later package release