### PR TITLE
Default the Antlers language target to runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
                         "regex",
                         "runtime"
                     ],
-                    "default": "regex",
+                    "default": "runtime",
                     "description": "The Antlers language version to use."
                 },
                 "antlersLanguageServer.formatFrontMatter": {


### PR DESCRIPTION
## Summary
- default the VS Code extension's Antlers language target to `runtime`
- align the extension manifest with the existing server, CLI, and Prettier defaults

## Testing
- `npm run lint`
- `npm test`