### PR TITLE
Prepare 2.8.0

### DIFF
--- a/antlersls/package-lock.json
+++ b/antlersls/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "antlers-language-server",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 1
 }

--- a/antlersls/package.json
+++ b/antlersls/package.json
@@ -1,6 +1,6 @@
 {
     "name": "antlers-language-server",
-    "version": "1.3.15",
+    "version": "1.3.16",
     "description": "The Antlers language server.",
     "main": "server.js",
     "bin": {

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,26 @@
 
 Bugs fixed, what's new, and more! :)
 
+## 2.8.0
+
+This release expands standards-based editor support and improves compatibility for non-VS Code language clients.
+
+### Language server and editor experience
+
+- Replaces the retired Blueprint Explorer project-detail notification and VS Code-specific broad file watcher with scoped, dynamically registered LSP file watchers. Project reloads are debounced, contained when they fail, and remain retryable. (#140)
+- Adds standard LSP range formatting while preserving surrounding indentation, LF or CRLF line endings, and existing trailing-newline behavior. (#142)
+- Exposes full-document and range semantic tokens through standard LSP requests, including project-aware token classifications and refresh support. (#143)
+- Adds project-aware workspace symbol search for Statamic views, partials, blueprints, fieldsets, globals, and fields, with cancellation and bounded results for large projects. (#144)
+- Adds optional Statamic field type inlay hints through `antlersLanguageServer.inlayHints.showFieldTypes`. The setting is disabled by default. (#145)
+- Defaults the Antlers language target to the current `runtime` implementation while keeping `regex` available for existing configurations. (#149)
+
+### Stability and project health
+
+- Hardens the VS Code debug runtime lifecycle by owning and cleaning up session resources, rejecting invalid Statamic storage paths before startup succeeds, and advertising only supported debugger capabilities. (#141)
+- Corrects parser content-offset tracking used by shared editor and formatter flows. (#148)
+- Repairs ESLint support for the ESM package, cleans the maintained TypeScript tree, and enforces linting in CI. (#146, #148)
+- Normalizes tracked text to LF and enforces consistent line endings across platforms. (#148)
+
 ## 2.7.0
 
 This is a large formatter, language support, stability, and project health release.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "antlers-statamic",
-    "version": "0.1.35",
+    "version": "0.1.36",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "antlers-statamic",
-            "version": "0.1.35",
+            "version": "0.1.36",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "0.1.35",
+    "version": "0.1.36",
     "publisher": "stillat",
     "engines": {
         "vscode": "^1.91.0"

--- a/formatcli/package/package-lock.json
+++ b/formatcli/package/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "antlers-formatter",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "lockfileVersion": 1
 }

--- a/formatcli/package/package.json
+++ b/formatcli/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "antlers-formatter",
-    "version": "1.2.15",
+    "version": "1.2.16",
     "description": "Formats Antlers template files.",
     "main": "cli.js",
     "bin": {

--- a/formatcli/prettier-plugin-antlers/package.json
+++ b/formatcli/prettier-plugin-antlers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-plugin-antlers",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Antlers Prettier plugin.",
     "type": "module",
     "main": "plugin.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-antlers",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-antlers",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/Stillat/vscode-antlers-language-server"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stillat-antlers-lsp",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "stillat-antlers-lsp",
-            "version": "1.2.20",
+            "version": "1.2.21",
             "license": "MIT",
             "dependencies": {
                 "@prettier/plugin-php": "^0.22",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stillat-antlers-lsp",
     "description": "Language server for Antlers.",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "author": "John Koster",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
## Summary
- add consolidated 2.8.0 changelog notes for PRs #140 through #149
- bump the extension to 2.8.0, the client to 0.1.36, the server to 1.2.21, and the standalone language server to 1.3.16
- bump the formatter CLI to 1.2.16 and the Prettier plugin to 2.0.7 because the shared parser content-offset fix from #148 is included in both bundles
- synchronize package-lock metadata with all version changes

## Validation
- `npm run lint`
- clean `npm test`: 410 server tests and 16 client tests pass
- dry-run npm packages for all six publishable manifests report the expected versions and contents
- `vscode-antlers-2.8.0.vsix` packages successfully and reports version 2.8.0
- inspected the VSIX to confirm the removed manifest-test output is absent

Generated CLI, Prettier, and standalone language-server bundles are intentionally deferred to a follow-up build PR, matching the 2.7.0 release workflow.