### PR TITLE
Prepare 2.8.1

### DIFF
--- a/antlersls/package-lock.json
+++ b/antlersls/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "antlers-language-server",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 1
 }

--- a/antlersls/package.json
+++ b/antlersls/package.json
@@ -1,6 +1,6 @@
 {
     "name": "antlers-language-server",
-    "version": "1.3.16",
+    "version": "1.3.17",
     "description": "The Antlers language server.",
     "main": "server.js",
     "bin": {

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 Bugs fixed, what's new, and more! :)
 
+## 2.8.1
+
+- Prevents empty or whitespace-only Antlers tags from producing invalid document symbol names while preserving valid descendant symbols. (#152)
+- Filters views, blueprints, and fields with empty names from workspace symbols, preventing VS Code's `name must not be falsy` error. (#152)
+
 ## 2.8.0
 
 This release expands standards-based editor support and improves compatibility for non-VS Code language clients.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "antlers-statamic",
-    "version": "0.1.36",
+    "version": "0.1.37",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "antlers-statamic",
-            "version": "0.1.36",
+            "version": "0.1.37",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "0.1.36",
+    "version": "0.1.37",
     "publisher": "stillat",
     "engines": {
         "vscode": "^1.91.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-antlers",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-antlers",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Provides Antlers syntax highlighting, formatting, error reporting, project-specific suggestions, and more.",
     "author": "John Koster",
     "license": "MIT",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/Stillat/vscode-antlers-language-server"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stillat-antlers-lsp",
-    "version": "1.2.21",
+    "version": "1.2.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "stillat-antlers-lsp",
-            "version": "1.2.21",
+            "version": "1.2.22",
             "license": "MIT",
             "dependencies": {
                 "@prettier/plugin-php": "^0.22",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stillat-antlers-lsp",
     "description": "Language server for Antlers.",
-    "version": "1.2.21",
+    "version": "1.2.22",
     "author": "John Koster",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
## Summary
- add focused 2.8.1 changelog notes for the empty symbol-name fix in #152
- bump the VS Code extension to 2.8.1
- bump the internal client to 0.1.37 and server to 1.2.22
- bump the standalone language server to 1.3.17
- leave the formatter CLI and Prettier plugin versions unchanged

## Validation
- `npm run lint`
- `npm test`: 412 server tests and 16 client tests pass
- dry-run packages for the extension, client, server, and standalone language server report the expected versions and contents

The standalone language-server bundle and final VSIX are intentionally handled in the follow-up build PR. Formatter bundles will not be rebuilt for this release.