### PR TITLE
Fix prefix loss and separator placement in array literals

### DIFF
--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -108,7 +108,7 @@ export class NodeBuffer {
     appendS(text: string) {
         let appendBuffer = '';
 
-        if (this.buffer.endsWith(' ') == false) {
+        if (/\s$/.test(this.buffer) == false) {
             appendBuffer += ' ';
         }
 
@@ -201,6 +201,26 @@ export class NodeBuffer {
 
     newLine() {
         this.buffer += "\n";
+
+        return this;
+    }
+
+    /**
+     * Removes the current line when it contains nothing but whitespace.
+     *
+     * Callers that are about to start a new line themselves use this to avoid
+     * leaving behind a line that holds only indentation.
+     */
+    trimBlankCurrentLine() {
+        const lineStart = this.buffer.lastIndexOf("\n");
+
+        if (lineStart == -1) {
+            return this;
+        }
+
+        if (this.buffer.substring(lineStart + 1).trim().length == 0) {
+            this.buffer = this.buffer.substring(0, lineStart);
+        }
 
         return this;
     }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -190,7 +190,8 @@ export class NodePrinter {
         const arrayWrapStack: ArrayPrintLayout[] = [],
             arrayWrapDecisions = options.arrayWrap == 'collapse'
                 ? new Map<string, ArrayWrapLayout>()
-                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
+                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc),
+            indentUnit = options.insertSpaces ? ' '.repeat(options.tabSize) : "\t";
         let nodeStatements = 0,
             nodeOperators = 0,
             arrayLiteralDepth = 0;
@@ -283,7 +284,19 @@ export class NodePrinter {
 
                         if ((!(node.prev instanceof VariableNode) || followsVariableStatement) &&
                             !(node.next instanceof InlineTernarySeparator) && !(node instanceof InlineTernarySeparator)) {
-                            nodeBuffer.newlineNDIndent();
+                            const arrayLayout = arrayWrapStack.length > 0
+                                ? arrayWrapStack[arrayWrapStack.length - 1]
+                                : null;
+
+                            if (arrayLayout != null && arrayLayout.wrap) {
+                                // Separators and closing brackets belong on the line of the value
+                                // they terminate, and everything else continues under its item.
+                                if (!(node instanceof ArgSeparator) && !(node instanceof ImplicitArrayEnd)) {
+                                    nodeBuffer.newLine().append(arrayLayout.itemIndent + indentUnit);
+                                }
+                            } else {
+                                nodeBuffer.newlineNDIndent();
+                            }
                         }
                     }
                 }
@@ -347,7 +360,7 @@ export class NodePrinter {
                             const layout = arrayWrapStack.pop();
 
                             if (layout?.wrap) {
-                                nodeBuffer.newLine().append(layout.closeIndent);
+                                nodeBuffer.trimBlankCurrentLine().newLine().append(layout.closeIndent);
                             }
 
                             nodeBuffer.append(']');
@@ -676,7 +689,7 @@ export class NodePrinter {
                     arrayLiteralDepth = Math.max(0, arrayLiteralDepth - 1);
 
                     if (layout?.wrap) {
-                        nodeBuffer.newLine().append(layout.closeIndent);
+                        nodeBuffer.trimBlankCurrentLine().newLine().append(layout.closeIndent);
                     }
 
                     nodeBuffer.append(node.content);

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -290,6 +290,7 @@ export class NodePrinter {
 
                 if (node instanceof VariableNode) {
                     if ((node.prev instanceof ImplicitArrayBegin || node.prev instanceof ImplicitArrayEnd) &&
+                        doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node.prev) &&
                         doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node)) {
                         continue;
                     }

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -243,6 +243,35 @@ after = values[2][1] }}`,
         assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
     });
 
+    test('prefixed variables keep their prefix inside array literals', () => {
+        const inputs = [
+            `{{ [view:size, 'shrink-0', classes] | classes }}`,
+            `{{ [page:title] | classes }}`,
+            `{{ [foo:bar:baz] | classes }}`,
+            `{{ [a, view:size] | classes }}`,
+            `{{ ['a' => view:size] | classes }}`
+        ];
+
+        inputs.forEach((input) => {
+            assert.strictEqual(formatAntlers(input).trim(), input);
+            assert.strictEqual(formatAntlers(input, formattingOptions('collapse')).trim(), input);
+        });
+    });
+
+    test('array accessors still collapse their merged components', () => {
+        const inputs = [
+            `{{ view:background['default'] }}`,
+            `{{ view:background['default']['one'] }}`,
+            `{{ posts[1].title }}`,
+            `{{ values = [['one'], [], ['two']]
+ after = values[2][1] }}`
+        ];
+
+        inputs.forEach((input) => {
+            assert.strictEqual(formatAntlers(input, formattingOptions('collapse')).trim(), input);
+        });
+    });
+
     test('multiple multi line arrays retain relative indentation', () => {
         const input = `{{ first = [
     'one',

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -272,6 +272,55 @@ after = values[2][1] }}`,
         });
     });
 
+    test('separators stay on the line of the value they terminate', () => {
+        const input = `{{ [
+    'one' => t !== 'a' && t !== 'b',
+    'two' => p
+] | classes }}`;
+
+        assert.strictEqual(formatAntlers(input), input);
+        assert.strictEqual(formatAntlers(formatAntlers(input)), input);
+    });
+
+    test('wrapped operator chains indent beneath their array item', () => {
+        const input = `{{ [
+    'one' => t !== 'a' && t !== 'b' && t !== 'c',
+    'two' => p
+] | classes }}`,
+            expected = `{{ [
+    'one' => t !== 'a' && t !== 'b'
+        && t !== 'c',
+    'two' => p
+] | classes }}`,
+            firstPass = formatAntlers(input);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass), firstPass);
+    });
+
+    test('wrapped operator chains use configured tabs', () => {
+        const input = `{{ [
+\t'one' => t !== 'a' && t !== 'b' && t !== 'c',
+\t'two' => p
+] | classes }}`,
+            expected = `{{ [
+\t'one' => t !== 'a' && t !== 'b'
+\t\t&& t !== 'c',
+\t'two' => p
+] | classes }}`,
+            options = formattingOptions('preserve', false),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('operator chains outside arrays are unaffected', () => {
+        const input = `{{ if t !== 'a' && t !== 'b' && t !== 'c' }}x{{ /if }}`;
+
+        assert.strictEqual(formatAntlers(input), formatAntlers(formatAntlers(input)));
+    });
+
     test('multiple multi line arrays retain relative indentation', () => {
         const input = `{{ first = [
     'one',


### PR DESCRIPTION
Fixes two array printing problems reported on #118. Both are reproducible on `main` and covered by new tests.

## 1. Prefixed variables lose their prefix inside array literals

`[view:size, 'shrink-0', classes]` is printed as `[:size, 'shrink-0', classes]`, which is not valid Antlers:

```
[ANTLR_031]: Unexpected [T_BRANCH_SEPARATOR] while parsing input text. Line 1 char 1.
```

Only the first element is affected, and any prefix is affected (`view:`, `page:`, and deeper paths). Prefixed variables outside array literals, key-value entries, and elements in position 2 or later were already correct. This regressed in v2.8.0 / plugin 2.0.6 (8c59410), not in #118 — v2.0.5 prints it correctly.

The printer skipped any merged variable component following an implicit array boundary. That guard is needed for array accessors such as `view:background['default']`, where the head component is printed again by the node carrying the full path. Array literals reuse the same boundary nodes, so the guard also dropped the leading path segment of a literal's first element.

The two cases are distinguishable: for an accessor the boundary node is itself a merged component, for a literal it is not. The fix requires that as well, so accessor output is untouched.

## 2. Separators and operator continuations do not line up with wrapped items

With `antlersArrayWrap: "preserve"`, an element containing more than one comparison produced:

```antlers
{{ [
    'one' => t !== 'a' && t !== 'b'
 && t !== 'c'
 ,
    'two' => p
] | classes }}
```

Now:

```antlers
{{ [
    'one' => t !== 'a' && t !== 'b'
        && t !== 'c',
    'two' => p
] | classes }}
```

Antlers breaks an expression across lines once it holds more than one comparison, and emits that break at the region indent. That predates #118 — v2.0.5 does the same — but with array wrapping the surrounding items are indented to their own level, so the two no longer agree, and a break landing right before a separator or a closing bracket pushes that token onto a line of its own. The same break also left a line holding only indentation before `]`.

Inside a wrapped array the continuation now indents one level under its item, a break immediately before a separator or closing bracket is dropped so the token stays with the value it terminates, and the closing bracket discards a blank indentation-only line.

`appendS` now treats any trailing whitespace as sufficient separation, the way `appendOS` already does, so a tab-indented continuation does not gain a leading space.

## Tests

Seven tests added to `formatter_array_wrap.test.ts`, covering prefixed elements in every position under both wrap styles, accessor output staying collapsed, separator placement, continuation indentation with spaces and with tabs, idempotency of each case, and operator chains outside arrays being unaffected.

`npm test` passes: 418 server (411 before these changes plus the 7 new) and 16 client, and `npm run lint` is clean.

Also verified end to end by building the plugin bundle and running `prettier --write` over a production Statamic project with condition-heavy `classes` arrays. Before: 33 templates emitted invalid `[:size`, plus 10 orphaned commas and 5 whitespace-only lines. After: none of those, the multi-line arrays reflow to one value per line, output is idempotent across repeated runs, and the project's own 177 tests pass.

The rebuilt `formatcli/prettier-plugin-antlers/plugin.js` bundle is deliberately left out of these commits, since it looks like it is regenerated at release time.
