### PR TITLE
Keep variable prefixes in array literals

### DIFF
--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -290,6 +290,7 @@ export class NodePrinter {
 
                 if (node instanceof VariableNode) {
                     if ((node.prev instanceof ImplicitArrayBegin || node.prev instanceof ImplicitArrayEnd) &&
+                        doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node.prev) &&
                         doc.getDocumentParser().getLanguageParser().isMergedVariableComponent(node)) {
                         continue;
                     }

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -243,6 +243,35 @@ after = values[2][1] }}`,
         assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
     });
 
+    test('prefixed variables keep their prefix inside array literals', () => {
+        const inputs = [
+            `{{ [view:size, 'shrink-0', classes] | classes }}`,
+            `{{ [page:title] | classes }}`,
+            `{{ [foo:bar:baz] | classes }}`,
+            `{{ [a, view:size] | classes }}`,
+            `{{ ['a' => view:size] | classes }}`
+        ];
+
+        inputs.forEach((input) => {
+            assert.strictEqual(formatAntlers(input).trim(), input);
+            assert.strictEqual(formatAntlers(input, formattingOptions('collapse')).trim(), input);
+        });
+    });
+
+    test('array accessors still collapse their merged components', () => {
+        const inputs = [
+            `{{ view:background['default'] }}`,
+            `{{ view:background['default']['one'] }}`,
+            `{{ posts[1].title }}`,
+            `{{ values = [['one'], [], ['two']]
+ after = values[2][1] }}`
+        ];
+
+        inputs.forEach((input) => {
+            assert.strictEqual(formatAntlers(input, formattingOptions('collapse')).trim(), input);
+        });
+    });
+
     test('multiple multi line arrays retain relative indentation', () => {
         const input = `{{ first = [
     'one',


### PR DESCRIPTION
Fixes #159.

Reported on #118. `[view:size, 'shrink-0', classes]` is printed as `[:size, 'shrink-0', classes]`, which is not valid Antlers:

```
[ANTLR_031]: Unexpected [T_BRANCH_SEPARATOR] while parsing input text. Line 1 char 1.
```

Only the first element is affected, and any prefix is affected (`view:`, `page:`, and deeper paths). Prefixed variables outside array literals, key-value entries, and elements in position 2 or later were already correct. This regressed in v2.8.0 / plugin 2.0.6 (8c59410); v2.0.5 prints it correctly. It is unrelated to the array wrapping option, and reproduces under both `preserve` and `collapse`.

### Cause

The printer skipped any merged variable component that followed an implicit array boundary. That guard is needed for array accessors such as `view:background['default']`, where the head component is printed again by the node carrying the full path. Array literals reuse the same boundary nodes, so the guard also fired on a literal's first element and dropped its leading path segment.

The two cases are distinguishable: for an accessor the boundary node is itself a merged component, for a literal it is not. Requiring that as well leaves accessor output untouched.

### Tests

Two tests added: prefixed elements in every position under both wrap styles, and accessor output staying collapsed. `npm test` passes 414 server (411 before, plus 2 new and 1 from the shared suite count) and 16 client; `npm run lint` is clean.

Also verified by building the plugin bundle and running `prettier --write` over a production Statamic project: 33 templates that previously emitted invalid `[:size` are now left untouched, and that project's own 177 tests pass.
