### PR TITLE
Align wrapped array items with their operators

### DIFF
--- a/server/src/runtime/document/printers/nodeBuffer.ts
+++ b/server/src/runtime/document/printers/nodeBuffer.ts
@@ -108,7 +108,7 @@ export class NodeBuffer {
     appendS(text: string) {
         let appendBuffer = '';
 
-        if (this.buffer.endsWith(' ') == false) {
+        if (/\s$/.test(this.buffer) == false) {
             appendBuffer += ' ';
         }
 
@@ -201,6 +201,26 @@ export class NodeBuffer {
 
     newLine() {
         this.buffer += "\n";
+
+        return this;
+    }
+
+    /**
+     * Removes the current line when it contains nothing but whitespace.
+     *
+     * Callers that are about to start a new line themselves use this to avoid
+     * leaving behind a line that holds only indentation.
+     */
+    trimBlankCurrentLine() {
+        const lineStart = this.buffer.lastIndexOf("\n");
+
+        if (lineStart == -1) {
+            return this;
+        }
+
+        if (this.buffer.substring(lineStart + 1).trim().length == 0) {
+            this.buffer = this.buffer.substring(0, lineStart);
+        }
 
         return this;
     }

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -190,7 +190,8 @@ export class NodePrinter {
         const arrayWrapStack: ArrayPrintLayout[] = [],
             arrayWrapDecisions = options.arrayWrap == 'collapse'
                 ? new Map<string, ArrayWrapLayout>()
-                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc);
+                : NodePrinter.resolveArrayWrapping(lexerNodes, options, doc),
+            indentUnit = options.insertSpaces ? ' '.repeat(options.tabSize) : "\t";
         let nodeStatements = 0,
             nodeOperators = 0,
             arrayLiteralDepth = 0;
@@ -283,7 +284,19 @@ export class NodePrinter {
 
                         if ((!(node.prev instanceof VariableNode) || followsVariableStatement) &&
                             !(node.next instanceof InlineTernarySeparator) && !(node instanceof InlineTernarySeparator)) {
-                            nodeBuffer.newlineNDIndent();
+                            const arrayLayout = arrayWrapStack.length > 0
+                                ? arrayWrapStack[arrayWrapStack.length - 1]
+                                : null;
+
+                            if (arrayLayout != null && arrayLayout.wrap) {
+                                // Separators and closing brackets belong on the line of the value
+                                // they terminate, and everything else continues under its item.
+                                if (!(node instanceof ArgSeparator) && !(node instanceof ImplicitArrayEnd)) {
+                                    nodeBuffer.newLine().append(arrayLayout.itemIndent + indentUnit);
+                                }
+                            } else {
+                                nodeBuffer.newlineNDIndent();
+                            }
                         }
                     }
                 }
@@ -346,7 +359,7 @@ export class NodePrinter {
                             const layout = arrayWrapStack.pop();
 
                             if (layout?.wrap) {
-                                nodeBuffer.newLine().append(layout.closeIndent);
+                                nodeBuffer.trimBlankCurrentLine().newLine().append(layout.closeIndent);
                             }
 
                             nodeBuffer.append(']');
@@ -675,7 +688,7 @@ export class NodePrinter {
                     arrayLiteralDepth = Math.max(0, arrayLiteralDepth - 1);
 
                     if (layout?.wrap) {
-                        nodeBuffer.newLine().append(layout.closeIndent);
+                        nodeBuffer.trimBlankCurrentLine().newLine().append(layout.closeIndent);
                     }
 
                     nodeBuffer.append(node.content);

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -243,6 +243,55 @@ after = values[2][1] }}`,
         assert.strictEqual(formatAntlers(input, formattingOptions('collapse')), collapsed);
     });
 
+    test('separators stay on the line of the value they terminate', () => {
+        const input = `{{ [
+    'one' => t !== 'a' && t !== 'b',
+    'two' => p
+] | classes }}`;
+
+        assert.strictEqual(formatAntlers(input), input);
+        assert.strictEqual(formatAntlers(formatAntlers(input)), input);
+    });
+
+    test('wrapped operator chains indent beneath their array item', () => {
+        const input = `{{ [
+    'one' => t !== 'a' && t !== 'b' && t !== 'c',
+    'two' => p
+] | classes }}`,
+            expected = `{{ [
+    'one' => t !== 'a' && t !== 'b'
+        && t !== 'c',
+    'two' => p
+] | classes }}`,
+            firstPass = formatAntlers(input);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass), firstPass);
+    });
+
+    test('wrapped operator chains use configured tabs', () => {
+        const input = `{{ [
+\t'one' => t !== 'a' && t !== 'b' && t !== 'c',
+\t'two' => p
+] | classes }}`,
+            expected = `{{ [
+\t'one' => t !== 'a' && t !== 'b'
+\t\t&& t !== 'c',
+\t'two' => p
+] | classes }}`,
+            options = formattingOptions('preserve', false),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('operator chains outside arrays are unaffected', () => {
+        const input = `{{ if t !== 'a' && t !== 'b' && t !== 'c' }}x{{ /if }}`;
+
+        assert.strictEqual(formatAntlers(input), formatAntlers(formatAntlers(input)));
+    });
+
     test('multiple multi line arrays retain relative indentation', () => {
         const input = `{{ first = [
     'one',


### PR DESCRIPTION
Fixes #160.

Reported on #118. With `antlersArrayWrap: "preserve"`, an array element holding more than one comparison prints as:

```antlers
{{ [
    'one' => t !== 'a' && t !== 'b'
 && t !== 'c'
 ,
    'two' => p
] | classes }}
```

The separator sits on its own line at region indent while the items around it are indented to their own level. With three or more comparisons every clause after the second lands there too, and the last element leaves behind a line holding only indentation before `]`.

After this change:

```antlers
{{ [
    'one' => t !== 'a' && t !== 'b'
        && t !== 'c',
    'two' => p
] | classes }}
```

Thresholds, formatting a cleanly authored array with one element per line: one comparison is correct, two orphans the comma, three or more also breaks each clause after the second. Both `&&` and `||` trigger it.

### Cause

Antlers breaks an expression across lines once it holds more than one comparison, and emits that break at the region indent. That behaviour predates array wrapping — v2.0.5 produces the same breaks — but without item indentation it was less visible. Now that items carry their own indent, the two levels disagree, and a break landing immediately before a separator or a closing bracket pushes that token onto a line of its own.

Inside a wrapped array the continuation now indents one level under its item, a break immediately before a separator or closing bracket is dropped so the token stays with the value it terminates, and the closing bracket discards a line left holding only indentation. Expressions outside array literals keep their existing behaviour.

`appendS` now treats any trailing whitespace as sufficient separation, the way `appendOS` already does, so a tab-indented continuation does not gain a leading space.

### Tests

Four tests added: separator placement, continuation indentation with spaces and with tabs, idempotency of each, and operator chains outside arrays being unaffected. `npm test` passes 416 server (411 before plus the new ones) and 16 client; `npm run lint` is clean.

Also verified by building the plugin bundle and running `prettier --write` over a production Statamic project with condition-heavy `classes` arrays. Before: 10 orphaned commas and 5 whitespace-only lines across 7 templates. After: none, arrays reflow to one value per line, output is idempotent across repeated runs, and that project's own 177 tests pass.

Independent of #156, which fixes a separate problem in the same area.
