### PR TITLE
Add expand array wrapping style

### DIFF
--- a/formatcli/package/README.md
+++ b/formatcli/package/README.md
@@ -48,7 +48,7 @@ The default Antlers formatter settings look like this when saved as JSON:
 * `insertSpaces` - Controls whether the Antlers formatter should insert spaces
 * `maxStatementsPerLine` - Suggests a maximum number of Antlers statements that should appear on a single line (i.e., `{{ test; test += 3; test += 5; }}`)
 * `tabSize` - The number of spaces to use for indentation
-* `arrayWrap` - Controls whether authored multi-line Antlers arrays are preserved or collapsed onto one line. Accepts `preserve` or `collapse` and defaults to `preserve`.
+* `arrayWrap` - Controls how Antlers arrays are wrapped. Accepts `preserve` (authored multi-line arrays keep their line breaks), `collapse` (always one line), or `expand` (always one item per line). Defaults to `preserve`.
 * `formatExtensions` - A list of file extensions that will be formatted when formatting a directory.
 
 The `htmlOptions` object may be used to set the HTML formatting options used by the Antlers formatter. These settings follow the same rules as the default [Visual Studio Code HTML Formatter](https://code.visualstudio.com/docs/languages/html#_formatting). The formatter will do its best to respect these settings, but may be unable to under certain circumstances.

--- a/formatcli/prettier-plugin-antlers/README.md
+++ b/formatcli/prettier-plugin-antlers/README.md
@@ -50,6 +50,7 @@ Controls how array literals inside Antlers regions are printed. Defaults to `pre
 |---|---|
 | `collapse` | Array literals are always printed on a single line. |
 | `preserve` | Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line. Arrays written on a single line stay on a single line. |
+| `expand` | Array literals are always printed across multiple lines, one item per line, whichever way they were written. |
 
 ```json
 {
@@ -75,6 +76,17 @@ With `preserve`, the same region keeps the line breaks it was written with:
         'font-semibold',
         'text-green',
         'underline' => is_current
+    ] | classes }}"
+>
+```
+
+With `expand`, an array written on one line is broken up as well:
+
+```html
+<span
+    class="{{ [
+        'block',
+        'font-semibold'
     ] | classes }}"
 >
 ```

--- a/package.json
+++ b/package.json
@@ -139,11 +139,12 @@
                     "type": "string",
                     "enum": [
                         "preserve",
-                        "collapse"
+                        "collapse",
+                        "expand"
                     ],
                     "default": "preserve",
                     "title": "Formatter: Array Wrapping",
-                    "description": "Controls whether authored multi-line Antlers arrays are preserved or collapsed onto one line."
+                    "description": "Controls how Antlers arrays are wrapped: preserve keeps authored line breaks, collapse always uses one line, expand always uses one item per line."
                 },
                 "antlersLanguageServer.inlayHints.showFieldTypes": {
                     "scope": "window",

--- a/server/src/formatting/beautifyDocumentFormatter.ts
+++ b/server/src/formatting/beautifyDocumentFormatter.ts
@@ -1,5 +1,6 @@
 import beautify from 'js-beautify';
 import { AntlersFormattingOptions } from './antlersFormattingOptions.js';
+import { resolveArrayWrapStyle } from '../runtime/document/transformOptions.js';
 import { DocumentFormatter } from './documentFormatter.js';
 import { FrontMatterFormatter } from './frontMatterFormatter.js';
 import { getFormatOption, getTagsFormatOption } from './htmlCompat.js';
@@ -25,7 +26,7 @@ export class BeautifyDocumentFormatter extends DocumentFormatter {
                 newlinesAfterFrontMatter: 1,
                 tabSize: options.tabSize,
                 insertSpaces: options.insertSpaces,
-                arrayWrap: options.arrayWrap == 'collapse' ? 'collapse' : 'preserve'
+                arrayWrap: resolveArrayWrapStyle(options.arrayWrap)
             });
     }
 

--- a/server/src/formatting/prettier/plugin.ts
+++ b/server/src/formatting/prettier/plugin.ts
@@ -82,6 +82,10 @@ const plugin: prettier.Plugin = {
                 {
                     value: 'preserve',
                     description: 'Array literals that span multiple lines in the source document keep spanning multiple lines, one item per line.'
+                },
+                {
+                    value: 'expand',
+                    description: 'Array literals are always printed across multiple lines, one item per line.'
                 }
             ]
         }

--- a/server/src/formatting/prettier/prettierDocumentFormatter.ts
+++ b/server/src/formatting/prettier/prettierDocumentFormatter.ts
@@ -4,16 +4,12 @@ import { formatAsHtml, setOptions } from './utils.js';
 import { FrontMatterFormatter } from '../frontMatterFormatter.js';
 import { ErrorPrinter } from '../../runtime/document/printers/errorPrinter.js';
 import { formatPhp } from '../phpFormatter.js';
-import { ArrayWrapStyle } from '../../runtime/document/transformOptions.js';
+import { ArrayWrapStyle, resolveArrayWrapStyle } from '../../runtime/document/transformOptions.js';
 
 function getArrayWrapStyle(options: prettier.ParserOptions): ArrayWrapStyle {
     const value = (options as unknown as Record<string, unknown>).antlersArrayWrap;
 
-    if (value === 'collapse') {
-        return 'collapse';
-    }
-
-    return 'preserve';
+    return resolveArrayWrapStyle(value as string | undefined);
 }
 
 export class PrettierDocumentFormatter extends DocumentFormatter {

--- a/server/src/runtime/document/printers/nodePrinter.ts
+++ b/server/src/runtime/document/printers/nodePrinter.ts
@@ -77,7 +77,8 @@ export class NodePrinter {
                 if (bracket == null) { continue; }
 
                 const layout: ArrayWrapLayout = {
-                    wrap: bracket.hasItems && line > bracket.line,
+                    wrap: bracket.hasItems &&
+                        (options.arrayWrap == 'expand' || line > bracket.line),
                     itemIndent: indentUnit.repeat(bracket.depth),
                     closeIndent: indentUnit.repeat(Math.max(0, bracket.depth - 1))
                 };
@@ -119,7 +120,8 @@ export class NodePrinter {
 
                 if (bracket == null) { continue; }
 
-                const wrap = bracket.hasItems && line > bracket.line,
+                const wrap = bracket.hasItems &&
+                    (options.arrayWrap == 'expand' || line > bracket.line),
                     closeKey = NodePrinter.bracketKey(i, parts.openCount + b);
 
                 const layout: ArrayWrapLayout = {

--- a/server/src/runtime/document/transformOptions.ts
+++ b/server/src/runtime/document/transformOptions.ts
@@ -5,7 +5,18 @@
  * preserve: Array literals that span multiple lines in the source document
  *           continue to span multiple lines, one item per line.
  */
-export type ArrayWrapStyle = 'preserve' | 'collapse';
+export type ArrayWrapStyle = 'preserve' | 'collapse' | 'expand';
+
+/**
+ * Resolves an untrusted array wrapping value, falling back to preserve.
+ */
+export function resolveArrayWrapStyle(value: string | undefined): ArrayWrapStyle {
+    if (value == 'collapse' || value == 'expand') {
+        return value;
+    }
+
+    return 'preserve';
+}
 
 export interface TransformOptions {
     tabSize: number,

--- a/server/src/runtime/document/transformer.ts
+++ b/server/src/runtime/document/transformer.ts
@@ -8,7 +8,7 @@ import { AsyncInlineFormatter, InlineFormatter } from './inlineFormatter.js';
 import { CommentPrinter } from './printers/commentPrinter.js';
 import { IndentLevel } from './printers/indentLevel.js';
 import { NodePrinter } from './printers/nodePrinter.js';
-import { TransformOptions } from './transformOptions.js';
+import { TransformOptions , resolveArrayWrapStyle } from './transformOptions.js';
 
 interface TransformedLogicBranch {
     branch: ExecutionBranch,
@@ -164,9 +164,7 @@ export class Transformer {
     withOptions(options: TransformOptions) {
         this.options = options;
 
-        if (this.options.arrayWrap != 'collapse' && this.options.arrayWrap != 'preserve') {
-            this.options.arrayWrap = 'preserve';
-        }
+        this.options.arrayWrap = resolveArrayWrapStyle(this.options.arrayWrap);
 
         if (this.options.tabSize <= 0) {
             this.options.tabSize = 4;
@@ -1067,7 +1065,7 @@ export class Transformer {
         for (const [slug, node] of this.inlineNodes) {
             const inline = this.selfClosing(slug),
                 inlineNs = this.selfClosingNs(slug),
-                preserveArrayIndent = this.options.arrayWrap == 'preserve' && this.hasArrayLiteral(node),
+                preserveArrayIndent = this.options.arrayWrap != 'collapse' && this.hasArrayLiteral(node),
                 printed = preserveArrayIndent
                     ? this.shiftSpanNode(await this.printNodeAsync(node), inline, 0)
                     : await this.printNodeAsync(node, this.indentLevel(inline));
@@ -1148,7 +1146,7 @@ export class Transformer {
         this.inlineNodes.forEach((node: AntlersNode, slug: string) => {
             const inline = this.selfClosing(slug),
                 inlineNs = this.selfClosingNs(slug),
-                preserveArrayIndent = this.options.arrayWrap == 'preserve' && this.hasArrayLiteral(node),
+                preserveArrayIndent = this.options.arrayWrap != 'collapse' && this.hasArrayLiteral(node),
                 printed = preserveArrayIndent
                     ? this.shiftSpanNode(this.printNode(node), inline, 0)
                     : this.printNode(node, this.indentLevel(inline));

--- a/server/src/test/formatter_array_wrap.test.ts
+++ b/server/src/test/formatter_array_wrap.test.ts
@@ -292,6 +292,67 @@ after = values[2][1] }}`,
         assert.strictEqual(formatAntlers(input), formatAntlers(formatAntlers(input)));
     });
 
+    test('expand wraps arrays that were authored on one line', () => {
+        const input = `{{ ['one', 'two' => condition] | classes }}`,
+            expected = `{{ [
+    'one',
+    'two' => condition
+] | classes }}`,
+            options = formattingOptions('expand'),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('expand wraps nested arrays at every level', () => {
+        const input = `{{ values = [['one'], ['two', ['three']]] }}`,
+            expected = `{{ values = [
+    [
+        'one'
+    ],
+    [
+        'two',
+        [
+            'three'
+        ]
+    ]
+] }}`,
+            options = formattingOptions('expand'),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('expand uses configured tabs', () => {
+        const input = `{{ ['one', 'two'] | classes }}`,
+            expected = `{{ [
+\t'one',
+\t'two'
+] | classes }}`,
+            options = formattingOptions('expand', false),
+            firstPass = formatAntlers(input, options);
+
+        assert.strictEqual(firstPass, expected);
+        assert.strictEqual(formatAntlers(firstPass, options), firstPass);
+    });
+
+    test('expand keeps empty arrays on one line', () => {
+        const input = `{{ values = [] }}`;
+
+        assert.strictEqual(formatAntlers(input, formattingOptions('expand')), input);
+    });
+
+    test('expand leaves quoted parameter arrays alone', () => {
+        const input = `{{ tag :items="[
+    'one',
+    ['two', 'three']
+]" }}`;
+
+        assert.strictEqual(formatAntlers(input, formattingOptions('expand')), input);
+    });
+
     test('multiple multi line arrays retain relative indentation', () => {
         const input = `{{ first = [
     'one',


### PR DESCRIPTION
Implements #161.

Related, from the same review of array printing:

- #159 — formatter drops variable prefix from first array element, fixed in #156
- #160 — separator comma and operator continuations misaligned in wrapped arrays, fixed in #157

Adds a third `antlersArrayWrap` value: `expand`.

> Built on #157 — its commit is included here, so this should merge after it. Without that fix `expand` would emit an orphaned comma in every condition-heavy array. The `expand` change itself is the last commit.

### Why

`preserve` and `collapse` both take the authored line breaks as their input: `preserve` keeps them, `collapse` removes them. Neither can turn an array written on one line into one item per line.

That leaves no way to ask for arrays to always read vertically, which is what you want for the long conditional class lists that the `classes` modifier encourages:

```antlers
class="{{ ['text-xs', 'transition-colors', 'hover:text-blue-500', 'hover:underline', 'underline-offset-2'] | classes }}"
```

With `preserve` this stays on one line, because there is no break to preserve. The only workaround is to hand-insert a newline into every array once, which is not practical across a template tree.

### Behaviour

| Value | Behaviour |
|---|---|
| `collapse` | always one line |
| `preserve` | authored line breaks are kept, one item per line |
| `expand` | always one item per line, however it was written |

```antlers
{{ ['one', 'two' => condition] | classes }}
```

becomes

```antlers
{{ [
    'one',
    'two' => condition
] | classes }}
```

Nested arrays expand at every level. Empty arrays stay `[]`, and quoted parameter arrays are left alone, matching the existing styles.

### Implementation note

The option value was narrowed back to `preserve` in three separate places (`beautifyDocumentFormatter`, `prettierDocumentFormatter`, and the transformer), so a new style could not reach the printer at all. Those now share a single `resolveArrayWrapStyle()` helper, which keeps the existing fallback behaviour for unrecognised values. The wrap decision itself is one condition, since `expand` is just the existing decision without the "was it already multi-line" test.

Registered in the prettier option `choices`, the VS Code setting enum, and both READMEs.

### Tests

Five tests added: expanding a single-line array, nested arrays at every level, tabs, empty arrays, and quoted parameter arrays — each also asserting idempotency. `npm test` passes 421 server and 16 client; `npm run lint` is clean.

Also verified by building the plugin bundle and running `prettier --write` over a production Statamic project: 74 templates reflow to one value per line, output is idempotent across repeated runs, and that project's own 177 tests pass.
